### PR TITLE
Show pairing and Tailscale connection controls in AirCodum

### DIFF
--- a/CONNECTION_SETUP.md
+++ b/CONNECTION_SETUP.md
@@ -1,3 +1,7 @@
+## Connect from the extension UI (0.2.2)
+
+Open **AirCodum** using **Open AirCodum Webview**. Under **Connect your phone**, use **Choose connection** and select the detected Tailscale address. This saves the address and starts the listener there. Connect Tailscale on both devices with the same account. Enter the displayed host and port in the phone app, choose **Tailscale / localhost (ws)**, and use **Copy pairing key** to transfer the key. The UI reports the active listener, even if the saved setting changes before restart. Start and stop controls remain available in the panel.
+
 # Connecting AirCodum to VS Code
 
 Use [AirCodum-Mobile](https://github.com/priyankark/AirCodum-Mobile), package `com.codeair`, with this extension. [AirCodum-Agnentum-Mobile](https://github.com/priyankark/AirCodum-Agnentum-Mobile) is the separate app for Agentum CLI.

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.2.2
+
+- Added connection controls showing the active host, port, and server status.
+- Added Copy pairing key and a detected Tailscale address selector.
+- Keep connection controls available when the server stops or fails to start.
+- Explain when localhost cannot be reached directly from a phone.
+
 # Changelog
 
 ## 0.2.0 (pre-release)

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,3 +1,7 @@
+## Connect your phone
+
+Open **AirCodum Webview** and use **Choose connection** to select the Mac’s Tailscale address. The panel shows the active host, port, and server status. Use **Copy pairing key** and paste the key in the mobile connection settings. Start and stop the listener from the same panel.
+
 # AirCodum: Smartphone powered Remote Control for VS Code
 
 ## Table of Contents

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aircodum-app",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aircodum-app",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@hurdlegroup/robotjs": "^0.12.2",
         "@types/node-fetch": "^2.6.11",

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "aircodum-app",
   "displayName": "AirCodum: Smartphone based Remote Control for VS Code",
   "description": "Smartphone based Remote Control for VS Code. Control IDE actions, send files and images, get AI assistance and more, right from your smartphone.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "publisher": "priyankark",
   "repository": "https://github.com/priyankark/AirCodum",
   "engines": {
@@ -35,6 +35,10 @@
       {
         "command": "extension.copyAirCodumPairingToken",
         "title": "AirCodum: Copy Pairing Token"
+      },
+      {
+        "command": "extension.configureAirCodumConnection",
+        "title": "AirCodum: Choose Connection"
       }
     ],
     "configuration": {

--- a/extension/src/connection.ts
+++ b/extension/src/connection.ts
@@ -1,0 +1,19 @@
+import type { NetworkInterfaceInfo } from "os";
+import { protectedBind } from "./security";
+
+export function tailscaleAddresses(interfaces: NodeJS.Dict<NetworkInterfaceInfo[]>): string[] {
+  return [...new Set(Object.values(interfaces).flatMap(entries => entries ?? [])
+    .filter(entry => !entry.internal && !entry.address.includes(":") && protectedBind(entry.address))
+    .map(entry => entry.address))].sort();
+}
+
+export function connectionDetails(server: { isRunning: boolean; address: string | null; port: number }, configured: string) {
+  const host = server.isRunning && server.address ? server.address : configured;
+  const local = host === "localhost" || host === "::1" || host.startsWith("127.");
+  return {
+    host, port: server.port, running: server.isRunning,
+    hint: !server.isRunning ? "Server stopped. Start it to connect your phone." : local
+      ? "This address is reachable only from this Mac. Choose connection → Tailscale to connect your phone directly."
+      : "Enter this host and port on your phone, then paste the pairing key.",
+  };
+}

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -19,30 +19,48 @@
 import * as vscode from "vscode";
 import { initializeSecrets, getPairingToken } from "./ai/utils";
 import { store } from "./state/store";
-import {
-  setServerAddress,
-  setServerRunning,
-} from "./state/actions";
 import { startServer, stopServer } from "./server";
 import { createWebviewPanel } from "./webview";
+import { networkInterfaces } from "os";
+import { tailscaleAddresses } from "./connection";
 
 export async function activate(context: vscode.ExtensionContext) {
   await initializeSecrets(context);
 
-  const startServerAndWebview = async () => {
-    if (store.getState().server.isRunning) {
-      vscode.window.showInformationMessage(
-        "AirCodum server is already running."
-      );
-      return;
-    }
-
-    const address = vscode.workspace.getConfiguration("aircodum").get<string>("bindAddress", "127.0.0.1");
-    await startServer(address, await getPairingToken());
-    setServerRunning(true);
-    setServerAddress(address);
-    createWebviewPanel(context, address);
+  const showPanel = () => {
+    const { webview } = store.getState();
+    if (webview.panel) webview.panel.reveal();
+    else createWebviewPanel(context);
   };
+
+  const startServerAndWebview = async () => {
+    showPanel();
+    if (store.getState().server.isRunning) return;
+    try {
+      const address = vscode.workspace.getConfiguration("aircodum").get<string>("bindAddress", "127.0.0.1");
+      await startServer(address, await getPairingToken());
+    } catch (error) {
+      vscode.window.showErrorMessage(`AirCodum could not start: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  };
+
+  context.subscriptions.push(vscode.commands.registerCommand("extension.configureAirCodumConnection", async () => {
+    const addresses = tailscaleAddresses(networkInterfaces());
+    const choices = addresses.map(address => ({ label: "Tailscale", description: address, address }));
+    choices.push({ label: "Localhost", description: "This Mac only, or a local TLS proxy", address: "127.0.0.1" });
+    const choice = await vscode.window.showQuickPick(choices, {
+      title: "AirCodum connection",
+      placeHolder: addresses.length ? "Choose the address your phone will connect to" : "No Tailscale address found. Connect Tailscale on this Mac, then try again.",
+    });
+    if (!choice) return;
+    try {
+      await vscode.workspace.getConfiguration("aircodum").update("bindAddress", choice.address, vscode.ConfigurationTarget.Global);
+      stopServer();
+      await startServerAndWebview();
+    } catch (error) {
+      vscode.window.showErrorMessage(`AirCodum connection failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }));
 
   const startServerCommand = vscode.commands.registerCommand(
     "extension.startAirCodumServer",
@@ -59,7 +77,7 @@ export async function activate(context: vscode.ExtensionContext) {
         if (!server.isRunning) {
           await startServerAndWebview();
         } else {
-          createWebviewPanel(context, server.address!);
+          createWebviewPanel(context);
         }
       }
     }

--- a/extension/src/server.ts
+++ b/extension/src/server.ts
@@ -3,7 +3,7 @@ import { WebSocketServer } from "ws";
 import * as vscode from "vscode";
 import { handleWebSocketConnection } from "./websockets";
 import { store } from "./state/store";
-import { setServerRunning, setWebSocketServer } from "./state/actions";
+import { setServerAddress, setServerRunning, setWebSocketServer } from "./state/actions";
 import { authorized, MAX_PAYLOAD, protectedBind } from "./security";
 
 let listener: http.Server | undefined;
@@ -28,6 +28,7 @@ export async function startServer(address: string, token: string): Promise<void>
       httpServer.listen(store.getState().server.port, address, () => {
         httpServer.removeListener("error", reject);
         httpServer.on("error", () => stopServer());
+        setServerAddress(address);
         setServerRunning(true);
         setWebSocketServer(wss);
         resolve();
@@ -41,11 +42,10 @@ export async function startServer(address: string, token: string): Promise<void>
 }
 
 export function stopServer(): void {
-  const { websocket, webview } = store.getState();
+  const { websocket } = store.getState();
   for (const client of websocket.wss?.clients ?? []) client.terminate();
   websocket.wss?.close();
   listener?.close(); listener = undefined;
   setWebSocketServer(null);
   setServerRunning(false);
-  webview.panel?.dispose();
 }

--- a/extension/src/webview.ts
+++ b/extension/src/webview.ts
@@ -4,6 +4,8 @@ import { setWebviewPanel } from "./state/actions";
 import { handleChat } from "./ai/api";
 
 import { randomBytes } from "crypto";
+import { store } from "./state/store";
+import { connectionDetails } from "./connection";
 
 function getWebviewContent(): string {
   const nonce = randomBytes(24).toString("hex");
@@ -52,6 +54,10 @@ function getWebviewContent(): string {
             cursor: pointer;
             transition: background-color 0.3s ease;
         }
+        .connection-actions { display: flex; flex-wrap: wrap; gap: 8px; }
+        button:disabled { opacity: 0.5; cursor: default; }
+        button:focus-visible { outline: 2px solid var(--vscode-focusBorder, #569cd6); outline-offset: 2px; }
+        .status-value { overflow-wrap: anywhere; }
         button:hover {
             background-color: #1177bb;
         }
@@ -112,17 +118,29 @@ function getWebviewContent(): string {
         <div class="logo">AirCodum</div>
         <div class="tagline">Airdrop for your Code</div>
         
-        <div class="status">
+        <h2>Connect your phone</h2>
+        <div class="status" aria-live="polite">
+            <div class="status-item"><span>Server:</span><span id="serverState" class="status-value"></span></div>
             <div class="status-item">
-                <span>IP Address:</span>
+                <span>Host:</span>
                 <span id="ipAddress" class="status-value"></span>
             </div>
             <div class="status-item">
                 <span>Port:</span>
-                <span class="status-value">11040</span>
+                <span id="serverPort" class="status-value"></span>
             </div>
         </div>
         
+        <p id="connectionHint"></p>
+        <p>On your phone, select <strong>Tailscale / localhost (ws)</strong> for a direct connection.
+        Connect Tailscale on both devices using the same account.</p>
+        <div class="connection-actions">
+            <button data-action="configureConnection">Choose connection</button>
+            <button data-action="copyPairingToken">Copy pairing key</button>
+            <button data-action="startServer">Start server</button>
+            <button data-action="stopServer">Stop server</button>
+        </div>
+        <p>The pairing key is required in the phone’s connection settings. Copy it here and paste it on your phone.</p>
         <div>
             <h2>OpenAI API Key</h2>
             <input type="password" id="apiKeyInput" placeholder="Enter your OpenAI API key">
@@ -160,7 +178,12 @@ function getWebviewContent(): string {
   
     <script nonce="${nonce}">
         const vscode = acquireVsCodeApi();
-        const actions = { saveApiKey, copyToClipboard, addToCurrentFile, chat };
+        const actions = { saveApiKey, copyToClipboard, addToCurrentFile, chat,
+          configureConnection: () => vscode.postMessage({command: 'configureConnection'}),
+          copyPairingToken: () => vscode.postMessage({command: 'copyPairingToken'}),
+          startServer: () => vscode.postMessage({command: 'startServer'}),
+          stopServer: () => vscode.postMessage({command: 'stopServer'}),
+        };
         document.querySelectorAll('[data-action]').forEach(button => {
           button.addEventListener('click', () => actions[button.dataset.action](button.dataset.target));
         });
@@ -222,8 +245,13 @@ function getWebviewContent(): string {
                 case 'chatResponse':
                     handleChatResponseMessage(message);
                     break;
-                case 'ipAddress':
-                    document.getElementById('ipAddress').textContent = message.ipAddress;
+                case 'connection':
+                    document.getElementById('ipAddress').textContent = message.host;
+                    document.getElementById('serverPort').textContent = String(message.port);
+                    document.getElementById('serverState').textContent = message.running ? 'Running' : 'Stopped';
+                    document.getElementById('connectionHint').textContent = message.hint;
+                    document.querySelector('[data-action="startServer"]').disabled = message.running;
+                    document.querySelector('[data-action="stopServer"]').disabled = !message.running;
                     break;
                 case 'error':
                     showError(message.message);
@@ -258,16 +286,14 @@ function getWebviewContent(): string {
             document.querySelectorAll('#chatContainer button').forEach(btn => btn.style.display = 'inline-block');
         }
   
-        // Request the API key when the webview loads
-        vscode.postMessage({ command: 'ipAddress' });
+        vscode.postMessage({ command: 'connection' });
     </script>
   </body>
   </html>`;
 }
 
 export function createWebviewPanel(
-  context: vscode.ExtensionContext,
-  address: string
+  context: vscode.ExtensionContext
 ) {
   const panel = vscode.window.createWebviewPanel(
     "AirCodum",
@@ -283,12 +309,17 @@ export function createWebviewPanel(
   panel.webview.html = getWebviewContent();
 
 
-  // Send the IP address to the webview
-  panel.webview.postMessage({ type: "ipAddress", ipAddress: address });
+  const sendConnection = () => {
+    const server = store.getState().server;
+    const configured = vscode.workspace.getConfiguration("aircodum").get<string>("bindAddress", "127.0.0.1");
+    panel.webview.postMessage({ type: "connection", ...connectionDetails(server, configured) });
+  };
+  const unsubscribe = store.subscribe(sendConnection);
 
   // Add this event listener
   panel.onDidDispose(
     () => {
+      unsubscribe();
       setWebviewPanel(null);
     },
     null,
@@ -302,8 +333,20 @@ export function createWebviewPanel(
         case "addToCurrentFile":
           addToCurrentFile(message.text);
           break;
-        case "ipAddress":
-          panel?.webview.postMessage({ type: "ipAddress", ipAddress: address });
+        case "connection":
+          sendConnection();
+          break;
+        case "configureConnection":
+          await vscode.commands.executeCommand("extension.configureAirCodumConnection");
+          break;
+        case "copyPairingToken":
+          await vscode.commands.executeCommand("extension.copyAirCodumPairingToken");
+          break;
+        case "startServer":
+          await vscode.commands.executeCommand("extension.startAirCodumServer");
+          break;
+        case "stopServer":
+          await vscode.commands.executeCommand("extension.stopAirCodumServer");
           break;
         case "saveApiKey":
           await saveApiKey(message.key);

--- a/extension/tests/connection.test.cjs
+++ b/extension/tests/connection.test.cjs
@@ -1,0 +1,25 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { tailscaleAddresses, connectionDetails } = require('../src/connection.ts');
+
+test('connection choices contain detected Tailscale addresses, never public or LAN adapters', () => {
+  const address = (address, internal = false) => ({ address, internal });
+  assert.deepEqual(tailscaleAddresses({
+    lo: [address('127.0.0.1', true)],
+    en0: [address('192.168.1.2'), address('10.0.0.2'), address('8.8.8.8')],
+    utun: [address('100.89.59.102'), address('fd7a:115c:a1e0::1234')],
+    duplicate: [address('100.89.59.102')],
+  }), ['100.89.59.102']);
+  assert.deepEqual(tailscaleAddresses({}), []);
+});
+
+test('panel reports the actual listener until restarted, and explains local-only access', () => {
+  const server = { isRunning: true, address: '127.0.0.1', port: 11040 };
+  const active = connectionDetails(server, '100.89.59.102');
+  assert.equal(active.host, '127.0.0.1');
+  assert.match(active.hint, /only from this Mac/);
+  const stopped = connectionDetails({ ...server, isRunning: false }, '100.89.59.102');
+  assert.equal(stopped.host, '100.89.59.102');
+  assert.match(stopped.hint, /Server stopped/);
+  assert.equal(connectionDetails({ ...server, address: '100.89.59.102' }, '127.0.0.1').running, true);
+});


### PR DESCRIPTION
The desktop connection details were scattered between commands and settings. A server bound to localhost looked ready even though a phone could not reach it.

The AirCodum panel now shows the active host, port and running status, with Copy pairing key, Choose connection, Start server and Stop server controls. Choosing a detected Tailscale IPv4 address saves it and restarts the listener. Localhost explains its access limitation, and the panel stays available after stopping or failing to start.

Version 0.2.2. QR pairing is deferred to a separate change. This PR targets the branch used for the published 0.2.1 runtime.

Validation: TypeScript and all eight regression tests pass. The final VSIX was loaded into isolated VS Code, where authenticated WebSocket connection, token copying, listener restart and persistent panel behavior passed. Packaged native libraries remain identical to 0.2.1.

Publication: the final VSIX was uploaded to the stable Marketplace channel; automatic Marketplace verification is pending. SHA-256: `b28d6d295c2f00c893e64362bdbc4c64ed896e888a0765d5acbe50745a1b726f`.

The public version-specific download serves the exact tested VSIX (SHA-256 matched). Installed locally without reloading the active user session; the Tailscale listener remains active.
