### PR TITLE
Add optional QR pairing and recovery from sleep interruptions

### DIFF
--- a/CONNECTION_SETUP.md
+++ b/CONNECTION_SETUP.md
@@ -1,3 +1,7 @@
+## Connect from the extension UI (0.2.2)
+
+Open **AirCodum** using **Open AirCodum Webview**. Under **Connect your phone**, use **Choose connection** and select the detected Tailscale address. This saves the address and starts the listener there. Connect Tailscale on both devices with the same account. Enter the displayed host and port in the phone app, choose **Tailscale / localhost (ws)**, and use **Copy pairing key** to transfer the key. The UI reports the active listener, even if the saved setting changes before restart. Start and stop controls remain available in the panel.
+
 # Connecting AirCodum to VS Code
 
 Use [AirCodum-Mobile](https://github.com/priyankark/AirCodum-Mobile), package `com.codeair`, with this extension. [AirCodum-Agnentum-Mobile](https://github.com/priyankark/AirCodum-Agnentum-Mobile) is the separate app for Agentum CLI.

--- a/CONNECTION_SETUP.md
+++ b/CONNECTION_SETUP.md
@@ -21,3 +21,11 @@ Send inserts the local text draft; Enter presses a separate desktop key. Leaving
 Validation commands: `npm run compile` and `npm run test:security` in the extension; `npx tsc --noEmit` and `npm run test:security` in the original mobile repo. See [NATIVE_VALIDATION.md](NATIVE_VALIDATION.md) for real VS Code and Android testing.
 
 The separate Agentum stack uses ports 11042/11043 and its own pairing credential. Its setup belongs to the [Agentum CLI PR](https://github.com/priyankark/agentum-cli/pull/3).
+
+## QR and sleep recovery (extension 0.2.3 / mobile 2.4.1)
+
+QR is optional; manual TLS/Tailscale host, port and token entry remains supported. QR images are generated locally and hidden when the listener changes. Both mobile platforms validate the payload, store the credential in SecureStore and use the existing authenticated handshake.
+
+Keep Mac awake holds a process-scoped macOS power assertion only while the server runs; stop, disable, or exit releases it. It changes no global power preferences. Lid closure can still force sleep. Apple-supported closed-display operation needs power, an external display, and keyboard/mouse. This extension cannot serve requests while the OS is asleep. Mobile retries continue with capped backoff while active, recover on foreground, and stop after Disconnect or authentication rejection.
+
+References: https://developer.apple.com/documentation/iokit/kiopmassertiontypepreventuseridlesystemsleep and https://support.apple.com/en-us/117373

--- a/NATIVE_VALIDATION.md
+++ b/NATIVE_VALIDATION.md
@@ -61,3 +61,8 @@ JavaScript and all native modules, is byte-identical. This promotion does not
 represent another native mobile E2E run; the runtime coverage above applies.
 
 GA VSIX SHA-256: `831d840500ab6c07b862296f223490f8e8f5a2824a05ff3e4cb748f20d099cf6`.
+
+The public Marketplace catalog confirmed 0.2.1 without the PreRelease property.
+The downloaded Marketplace package matched the GA SHA-256 after HTTP gzip
+decoding. A fresh isolated VS Code 1.121.0 profile installed
+`priyankark.aircodum-app` as 0.2.1 without `--pre-release` or a pinned version.

--- a/NATIVE_VALIDATION.md
+++ b/NATIVE_VALIDATION.md
@@ -47,3 +47,17 @@ Android used a universal emulator APK derived from the production AirCodum-Mobil
 The opt-in host setting `AIRCODUM_E2E_FOCUS_HOLD_MS=10000` keeps only its isolated VS Code process in front for up to ten seconds after focus requests during automation. Keep macOS awake and reserve the desktop for these tests. Mobile drivers also wake Android, reject stale UI hierarchies and pace native XCTest typing. These test-driver changes do not change the released extension runtime.
 
 VSIX SHA-256: `2817f4d109d8edd58c9819c77bf6c0e0e2105dc1da070e62c3d07ef893167c9e`. Full release/build/submission status is tracked in AirCodum-Mobile's STORE_RELEASE.md. Physical devices, production TLS/Tailscale, Windows/Linux and camera/file-picker/voice/AI flows remain outside this validation.
+
+## GA promotion — September 10, 2026
+
+Version 0.2.1 promotes the tested 0.2.0 runtime to the stable Marketplace channel
+after iOS AirCodum 2.4.0 reached READY_FOR_SALE. Android build 28 remains in review.
+Marketplace requires different version numbers for pre-release and stable builds.
+The GA VSIX was made from the verified original VSIX, preserving each ZIP entry's
+metadata and bytes except `extension/package.json` (version 0.2.0 → 0.2.1) and
+`extension.vsixmanifest` (version increment and removal of PreRelease=true).
+Comparison of all 14 entries confirmed that every runtime file, including bundled
+JavaScript and all native modules, is byte-identical. This promotion does not
+represent another native mobile E2E run; the runtime coverage above applies.
+
+GA VSIX SHA-256: `831d840500ab6c07b862296f223490f8e8f5a2824a05ff3e4cb748f20d099cf6`.

--- a/REVIEW_SETUP.md
+++ b/REVIEW_SETUP.md
@@ -13,17 +13,16 @@ registration, or one-time login code. Desktop setup is required.
 - [AirCodum: Control VS Code right from your phone!](https://youtu.be/HXtH_NYY2Lc)
   — the demo linked in the extension documentation.
 
-The steps below describe the current 2.4.0 app / 0.2.0 extension pairing process.
+The steps below describe the current 2.4.0 app / 0.2.1 extension pairing process.
 
 ## Install the published extension
 
 1. Install [Visual Studio Code](https://code.visualstudio.com/) on a computer.
 2. Open Extensions and search for `priyankark.aircodum-app`, or open its
    [published Marketplace page](https://marketplace.visualstudio.com/items?itemName=priyankark.aircodum-app).
-3. Select **Install Pre-Release Version**, or **Switch to Pre-Release Version**
-   if already installed. Confirm extension version **0.2.0**. The stable channel
-   remains 0.1.11 and does not provide the new pairing commands.
-   Alternatively, install the [published 0.2.0 VSIX](https://github.com/priyankark/AirCodum/releases/tag/v0.2.0)
+3. Select **Install** or update the extension. Confirm stable version **0.2.1**.
+   If using the pre-release channel, **Switch to Release Version** is also available.
+   Alternatively, install the [published 0.2.1 VSIX](https://github.com/priyankark/AirCodum/releases/tag/v0.2.1)
    using **Extensions: Install from VSIX**.
 4. Open a disposable folder in VS Code and trust that folder. Create and open
    `review.txt` containing sample text. Keep VS Code and that editor in front

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.2.2
+
+- Added connection controls showing the active host, port, and server status.
+- Added Copy pairing key and a detected Tailscale address selector.
+- Keep connection controls available when the server stops or fails to start.
+- Explain when localhost cannot be reached directly from a phone.
+
 # Changelog
 
 ## 0.2.0 (pre-release)

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.3
+
+- Added QR pairing with AirCodum mobile 2.4.1; manual connection controls remain available.
+- Added Keep Mac awake while the server runs, with guidance for supported closed-display use.
+- Added heartbeat support and removal of stale connections after sleep or network interruption.
+
 ## 0.2.2
 
 - Added connection controls showing the active host, port, and server status.

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,3 +1,7 @@
+## Connect your phone
+
+Open **AirCodum Webview** and use **Choose connection** to select the Mac’s Tailscale address. The panel shows the active host, port, and server status. Use **Copy pairing key** and paste the key in the mobile connection settings. Start and stop the listener from the same panel.
+
 # AirCodum: Smartphone powered Remote Control for VS Code
 
 ## Table of Contents

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,3 +1,9 @@
+## Scan to connect
+
+With AirCodum mobile 2.4.1 or later, choose your Tailscale connection in this extension and click **Show pairing QR**. Tap **Scan QR to connect** on Android or iOS. The scan fills host, port, transport and pairing key and connects. Manual connection and Copy pairing key remain available.
+
+**Keep Mac awake** prevents idle sleep while the server is running. It does not override macOS lid-close sleep. For supported closed-display use, connect power, an external display, and a keyboard and mouse. The mobile app retries when the desktop becomes reachable again.
+
 ## Connect your phone
 
 Open **AirCodum Webview** and use **Choose connection** to select the Mac’s Tailscale address. The panel shows the active host, port, and server status. Use **Copy pairing key** and paste the key in the mobile connection settings. Start and stop the listener from the same panel.

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aircodum-app",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aircodum-app",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@hurdlegroup/robotjs": "^0.12.2",
         "@types/node-fetch": "^2.6.11",

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aircodum-app",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aircodum-app",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@hurdlegroup/robotjs": "^0.12.2",
         "@types/node-fetch": "^2.6.11",
@@ -18,18 +18,21 @@
         "node-fetch": "^2.7.0",
         "node-webp": "^1.0.2",
         "openai": "^4.67.0",
+        "qrcode": "^1.5.4",
         "screenshot-desktop": "^1.15.2",
         "ws": "^8.18.0"
       },
       "devDependencies": {
         "@types/jimp": "^0.2.1",
         "@types/node": "^18",
+        "@types/qrcode": "^1.5.6",
         "@types/vscode": "^1.73.0",
         "@types/ws": "^8.5.12",
         "@typescript-eslint/eslint-plugin": "^7.14.0",
         "@typescript-eslint/parser": "^7.14.0",
         "esbuild": "^0.25.0",
         "eslint": "^8.26.0",
+        "jsqr": "^1.4.0",
         "npm-run-all": "^4.1.5",
         "typescript": "^5.5.2"
       },
@@ -1072,6 +1075,16 @@
         "form-data": "^4.0.0"
       }
     },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/screenshot-desktop": {
       "version": "1.12.3",
       "resolved": "https://registry.npmjs.org/@types/screenshot-desktop/-/screenshot-desktop-1.12.3.tgz",
@@ -1380,7 +1393,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -1389,7 +1401,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -1581,6 +1592,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1597,11 +1617,21 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -1612,8 +1642,7 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -1718,6 +1747,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1768,6 +1806,12 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -1832,6 +1876,12 @@
       "funding": {
         "url": "https://bevry.me/fund"
       }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/encoding": {
       "version": "0.1.13",
@@ -2419,6 +2469,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -2923,6 +2982,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -3203,6 +3271,13 @@
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "node_modules/jsqr": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsqr/-/jsqr-1.4.0.tgz",
+      "integrity": "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -3773,6 +3848,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -3831,7 +3915,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3963,6 +4046,32 @@
         "node": ">=6"
       }
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -4029,6 +4138,21 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -4186,6 +4310,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -4327,6 +4457,20 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string.prototype.padend": {
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.6.tgz",
@@ -4402,7 +4546,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -4828,6 +4971,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
@@ -4855,6 +5004,20 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {
@@ -4909,6 +5072,99 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {
@@ -5550,6 +5806,15 @@
         "form-data": "^4.0.0"
       }
     },
+    "@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/screenshot-desktop": {
       "version": "1.12.3",
       "resolved": "https://registry.npmjs.org/@types/screenshot-desktop/-/screenshot-desktop-1.12.3.tgz",
@@ -5739,14 +6004,12 @@
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
       }
@@ -5877,6 +6140,11 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+    },
     "chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -5887,11 +6155,20 @@
         "supports-color": "^7.1.0"
       }
     },
+    "cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
@@ -5899,8 +6176,7 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -5967,6 +6243,11 @@
         "ms": "^2.1.3"
       }
     },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
+    },
     "deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -5999,6 +6280,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+    },
+    "dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA=="
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -6040,6 +6326,11 @@
       "requires": {
         "version-range": "^4.13.0"
       }
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "encoding": {
       "version": "0.1.13",
@@ -6485,6 +6776,11 @@
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true
     },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+    },
     "get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -6815,6 +7111,11 @@
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+    },
     "is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -7002,6 +7303,12 @@
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       }
+    },
+    "jsqr": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsqr/-/jsqr-1.4.0.tgz",
+      "integrity": "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==",
+      "dev": true
     },
     "levn": {
       "version": "0.4.1",
@@ -7378,6 +7685,11 @@
         "p-limit": "^3.0.2"
       }
     },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+    },
     "pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -7424,8 +7736,7 @@
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -7506,6 +7817,23 @@
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true
     },
+    "qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "requires": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "dependencies": {
+        "pngjs": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+          "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="
+        }
+      }
+    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -7545,6 +7873,16 @@
         "es-errors": "^1.3.0",
         "set-function-name": "^2.0.2"
       }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "resolve": {
       "version": "1.22.8",
@@ -7635,6 +7973,11 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
     "set-function-length": {
       "version": "1.2.2",
@@ -7738,6 +8081,16 @@
       "integrity": "sha512-jg25NiDV/1fLtSgEgyvVyDunvaNHbuwF9lfNV17gSmPFAlYzdfNBlLtLzXTevwkPj7DhGbmN9VnmJIgLnhvaBw==",
       "dev": true
     },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
     "string.prototype.padend": {
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.6.tgz",
@@ -7788,7 +8141,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }
@@ -8070,6 +8422,11 @@
         "is-symbol": "^1.0.3"
       }
     },
+    "which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="
+    },
     "which-typed-array": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
@@ -8088,6 +8445,16 @@
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true
+    },
+    "wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
     },
     "wrappy": {
       "version": "1.0.2",
@@ -8118,6 +8485,73 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+    },
+    "y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+    },
+    "yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "requires": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aircodum-app",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aircodum-app",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@hurdlegroup/robotjs": "^0.12.2",
         "@types/node-fetch": "^2.6.11",

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "aircodum-app",
   "displayName": "AirCodum: Smartphone based Remote Control for VS Code",
   "description": "Smartphone based Remote Control for VS Code. Control IDE actions, send files and images, get AI assistance and more, right from your smartphone.",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "publisher": "priyankark",
   "repository": "https://github.com/priyankark/AirCodum",
   "engines": {
@@ -39,6 +39,10 @@
       {
         "command": "extension.configureAirCodumConnection",
         "title": "AirCodum: Choose Connection"
+      },
+      {
+        "command": "extension.toggleAirCodumKeepAwake",
+        "title": "AirCodum: Toggle Keep Mac Awake"
       }
     ],
     "configuration": {
@@ -49,6 +53,12 @@
           "default": "127.0.0.1",
           "scope": "application",
           "description": "Listen address. For remote access, use your encrypted VPN interface address or a TLS proxy."
+        },
+        "aircodum.keepAwake": {
+          "type": "boolean",
+          "default": false,
+          "scope": "application",
+          "description": "On macOS, prevent idle sleep while the AirCodum server runs. Does not override lid-close sleep; supported closed-display use requires power and an external display."
         }
       }
     }
@@ -66,12 +76,14 @@
   "devDependencies": {
     "@types/jimp": "^0.2.1",
     "@types/node": "^18",
+    "@types/qrcode": "^1.5.6",
     "@types/vscode": "^1.73.0",
     "@types/ws": "^8.5.12",
     "@typescript-eslint/eslint-plugin": "^7.14.0",
     "@typescript-eslint/parser": "^7.14.0",
     "esbuild": "^0.25.0",
     "eslint": "^8.26.0",
+    "jsqr": "^1.4.0",
     "npm-run-all": "^4.1.5",
     "typescript": "^5.5.2"
   },
@@ -86,6 +98,7 @@
     "node-fetch": "^2.7.0",
     "node-webp": "^1.0.2",
     "openai": "^4.67.0",
+    "qrcode": "^1.5.4",
     "screenshot-desktop": "^1.15.2",
     "ws": "^8.18.0"
   },

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "aircodum-app",
   "displayName": "AirCodum: Smartphone based Remote Control for VS Code",
   "description": "Smartphone based Remote Control for VS Code. Control IDE actions, send files and images, get AI assistance and more, right from your smartphone.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "publisher": "priyankark",
   "repository": "https://github.com/priyankark/AirCodum",
   "engines": {
@@ -35,6 +35,10 @@
       {
         "command": "extension.copyAirCodumPairingToken",
         "title": "AirCodum: Copy Pairing Token"
+      },
+      {
+        "command": "extension.configureAirCodumConnection",
+        "title": "AirCodum: Choose Connection"
       }
     ],
     "configuration": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "aircodum-app",
   "displayName": "AirCodum: Smartphone based Remote Control for VS Code",
   "description": "Smartphone based Remote Control for VS Code. Control IDE actions, send files and images, get AI assistance and more, right from your smartphone.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "publisher": "priyankark",
   "repository": "https://github.com/priyankark/AirCodum",
   "engines": {

--- a/extension/src/connection.ts
+++ b/extension/src/connection.ts
@@ -1,0 +1,19 @@
+import type { NetworkInterfaceInfo } from "os";
+import { protectedBind } from "./security";
+
+export function tailscaleAddresses(interfaces: NodeJS.Dict<NetworkInterfaceInfo[]>): string[] {
+  return [...new Set(Object.values(interfaces).flatMap(entries => entries ?? [])
+    .filter(entry => !entry.internal && !entry.address.includes(":") && protectedBind(entry.address))
+    .map(entry => entry.address))].sort();
+}
+
+export function connectionDetails(server: { isRunning: boolean; address: string | null; port: number }, configured: string) {
+  const host = server.isRunning && server.address ? server.address : configured;
+  const local = host === "localhost" || host === "::1" || host.startsWith("127.");
+  return {
+    host, port: server.port, running: server.isRunning,
+    hint: !server.isRunning ? "Server stopped. Start it to connect your phone." : local
+      ? "This address is reachable only from this Mac. Choose connection → Tailscale to connect your phone directly."
+      : "Enter this host and port on your phone, then paste the pairing key.",
+  };
+}

--- a/extension/src/connection.ts
+++ b/extension/src/connection.ts
@@ -4,7 +4,7 @@ import { protectedBind } from "./security";
 export function tailscaleAddresses(interfaces: NodeJS.Dict<NetworkInterfaceInfo[]>): string[] {
   return [...new Set(Object.values(interfaces).flatMap(entries => entries ?? [])
     .filter(entry => !entry.internal && !entry.address.includes(":") && protectedBind(entry.address))
-    .map(entry => entry.address))].sort();
+    .map(entry => entry.address))].sort((a, b) => Number(a.includes(":")) - Number(b.includes(":")) || a.localeCompare(b));
 }
 
 export function connectionDetails(server: { isRunning: boolean; address: string | null; port: number }, configured: string) {
@@ -16,4 +16,14 @@ export function connectionDetails(server: { isRunning: boolean; address: string 
       ? "This address is reachable only from this Mac. Choose connection → Tailscale to connect your phone directly."
       : "Enter this host and port on your phone, then paste the pairing key.",
   };
+}
+
+export function pairingCode(server: { isRunning: boolean; address: string | null; port: number }, token: string): string {
+  if (!server.isRunning || !server.address) throw new Error('Start the server before showing a pairing code.');
+  const host = server.address;
+  if (host === 'localhost' || host === '::1' || host.startsWith('127.')) {
+    throw new Error('Choose connection → Tailscale first so your phone can reach this Mac.');
+  }
+  if (!protectedBind(host) || !/^[a-zA-Z0-9_-]{32,256}$/.test(token)) throw new Error('Invalid pairing settings.');
+  return JSON.stringify({ type: 'aircodum-pairing', version: 1, host: host.includes(':') ? `[${host}]` : host, port: server.port, tls: false, token });
 }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -19,30 +19,48 @@
 import * as vscode from "vscode";
 import { initializeSecrets, getPairingToken } from "./ai/utils";
 import { store } from "./state/store";
-import {
-  setServerAddress,
-  setServerRunning,
-} from "./state/actions";
 import { startServer, stopServer } from "./server";
 import { createWebviewPanel } from "./webview";
+import { networkInterfaces } from "os";
+import { tailscaleAddresses } from "./connection";
 
 export async function activate(context: vscode.ExtensionContext) {
   await initializeSecrets(context);
 
-  const startServerAndWebview = async () => {
-    if (store.getState().server.isRunning) {
-      vscode.window.showInformationMessage(
-        "AirCodum server is already running."
-      );
-      return;
-    }
-
-    const address = vscode.workspace.getConfiguration("aircodum").get<string>("bindAddress", "127.0.0.1");
-    await startServer(address, await getPairingToken());
-    setServerRunning(true);
-    setServerAddress(address);
-    createWebviewPanel(context, address);
+  const showPanel = () => {
+    const { webview } = store.getState();
+    if (webview.panel) webview.panel.reveal();
+    else createWebviewPanel(context);
   };
+
+  const startServerAndWebview = async () => {
+    showPanel();
+    if (store.getState().server.isRunning) return;
+    try {
+      const address = vscode.workspace.getConfiguration("aircodum").get<string>("bindAddress", "127.0.0.1");
+      await startServer(address, await getPairingToken());
+    } catch (error) {
+      vscode.window.showErrorMessage(`AirCodum could not start: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  };
+
+  context.subscriptions.push(vscode.commands.registerCommand("extension.configureAirCodumConnection", async () => {
+    const addresses = tailscaleAddresses(networkInterfaces());
+    const choices = addresses.map(address => ({ label: "Tailscale", description: address, address }));
+    choices.push({ label: "Localhost", description: "This Mac only, or a local TLS proxy", address: "127.0.0.1" });
+    const choice = await vscode.window.showQuickPick(choices, {
+      title: "AirCodum connection",
+      placeHolder: addresses.length ? "Choose the address your phone will connect to" : "No Tailscale address found. Connect Tailscale on this Mac, then try again.",
+    });
+    if (!choice) return;
+    try {
+      await vscode.workspace.getConfiguration("aircodum").update("bindAddress", choice.address, vscode.ConfigurationTarget.Global);
+      stopServer();
+      await startServerAndWebview();
+    } catch (error) {
+      vscode.window.showErrorMessage(`AirCodum connection failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }));
 
   const startServerCommand = vscode.commands.registerCommand(
     "extension.startAirCodumServer",
@@ -59,7 +77,7 @@ export async function activate(context: vscode.ExtensionContext) {
         if (!server.isRunning) {
           await startServerAndWebview();
         } else {
-          createWebviewPanel(context, server.address!);
+          createWebviewPanel(context);
         }
       }
     }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -21,11 +21,24 @@ import { initializeSecrets, getPairingToken } from "./ai/utils";
 import { store } from "./state/store";
 import { startServer, stopServer } from "./server";
 import { createWebviewPanel } from "./webview";
+import { KeepAwake } from "./keep-awake";
 import { networkInterfaces } from "os";
 import { tailscaleAddresses } from "./connection";
 
 export async function activate(context: vscode.ExtensionContext) {
   await initializeSecrets(context);
+  const updatePowerStatus = () => store.getState().webview.panel?.webview.postMessage({ type: 'power', active: keepAwake.active });
+  const keepAwake = new KeepAwake(updatePowerStatus, message => { vscode.window.showErrorMessage(message); });
+  const syncPower = () => keepAwake.update(vscode.workspace.getConfiguration('aircodum').get<boolean>('keepAwake', false), store.getState().server.isRunning);
+  const unsubscribePower = store.subscribe(syncPower);
+  context.subscriptions.push({ dispose: () => { unsubscribePower(); keepAwake.stop(); } });
+  context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(event => { if (event.affectsConfiguration('aircodum.keepAwake')) syncPower(); }));
+  context.subscriptions.push(vscode.commands.registerCommand('extension.toggleAirCodumKeepAwake', async () => {
+    const config = vscode.workspace.getConfiguration('aircodum');
+    await config.update('keepAwake', !config.get<boolean>('keepAwake', false), vscode.ConfigurationTarget.Global);
+    syncPower(); updatePowerStatus();
+  }));
+  context.subscriptions.push(vscode.commands.registerCommand('extension.aircodumPowerStatus', updatePowerStatus));
 
   const showPanel = () => {
     const { webview } = store.getState();

--- a/extension/src/keep-awake.ts
+++ b/extension/src/keep-awake.ts
@@ -1,0 +1,26 @@
+import { ChildProcess, spawn } from 'child_process';
+
+/** Process-scoped macOS assertions; never changes global power-management preferences. */
+export class KeepAwake {
+  private child: ChildProcess | undefined;
+  constructor(private changed: () => void, private failed: (message: string) => void) {}
+  get active(): boolean { return !!this.child?.pid; }
+  update(enabled: boolean, running: boolean): void {
+    if (!enabled || !running || process.platform !== 'darwin') { this.stop(); return; }
+    if (this.child) return;
+    const child = spawn('/usr/bin/caffeinate', ['-is', '-w', String(process.pid)], { stdio: 'ignore' });
+    this.child = child;
+    child.once('spawn', this.changed);
+    child.once('error', () => {
+      if (this.child !== child) return;
+      this.child = undefined; this.changed();
+      this.failed('AirCodum could not enable Keep Mac awake. Check your Mac’s power settings.');
+    });
+    child.once('exit', () => { if (this.child === child) { this.child = undefined; this.changed(); } });
+  }
+  stop(): void {
+    const child = this.child; this.child = undefined;
+    child?.kill();
+    if (child) this.changed();
+  }
+}

--- a/extension/src/server.ts
+++ b/extension/src/server.ts
@@ -20,7 +20,23 @@ export async function startServer(address: string, token: string): Promise<void>
     server: httpServer, maxPayload: MAX_PAYLOAD, perMessageDeflate: false,
     verifyClient: ({ req }: { req: import('http').IncomingMessage }) => wss.clients.size < 4 && authorized(req, token),
   });
-  wss.on("connection", handleWebSocketConnection);
+  // The HTTP listener owns startup/runtime errors; consume ws’s forwarded copy.
+  wss.on("error", () => {});
+  const alive = new WeakMap<import('ws'), boolean>();
+  wss.on('connection', socket => {
+    alive.set(socket, true);
+    socket.on('pong', () => alive.set(socket, true));
+    handleWebSocketConnection(socket);
+  });
+  const heartbeat = setInterval(() => {
+    for (const socket of wss.clients) {
+      if (!alive.get(socket)) { socket.terminate(); continue; }
+      alive.set(socket, false);
+      socket.ping();
+    }
+  }, 30000);
+  heartbeat.unref();
+  wss.once('close', () => clearInterval(heartbeat));
   listener = httpServer;
   try {
     await new Promise<void>((resolve, reject) => {

--- a/extension/src/server.ts
+++ b/extension/src/server.ts
@@ -3,7 +3,7 @@ import { WebSocketServer } from "ws";
 import * as vscode from "vscode";
 import { handleWebSocketConnection } from "./websockets";
 import { store } from "./state/store";
-import { setServerRunning, setWebSocketServer } from "./state/actions";
+import { setServerAddress, setServerRunning, setWebSocketServer } from "./state/actions";
 import { authorized, MAX_PAYLOAD, protectedBind } from "./security";
 
 let listener: http.Server | undefined;
@@ -28,6 +28,7 @@ export async function startServer(address: string, token: string): Promise<void>
       httpServer.listen(store.getState().server.port, address, () => {
         httpServer.removeListener("error", reject);
         httpServer.on("error", () => stopServer());
+        setServerAddress(address);
         setServerRunning(true);
         setWebSocketServer(wss);
         resolve();
@@ -41,11 +42,10 @@ export async function startServer(address: string, token: string): Promise<void>
 }
 
 export function stopServer(): void {
-  const { websocket, webview } = store.getState();
+  const { websocket } = store.getState();
   for (const client of websocket.wss?.clients ?? []) client.terminate();
   websocket.wss?.close();
   listener?.close(); listener = undefined;
   setWebSocketServer(null);
   setServerRunning(false);
-  webview.panel?.dispose();
 }

--- a/extension/src/websockets.ts
+++ b/extension/src/websockets.ts
@@ -351,6 +351,7 @@ class VSCodeVNCConnection {
         }
         const data = JSON.parse(text);
         switch (data.type) {
+          case 'ping': this.ws.send(JSON.stringify({ type: 'pong' })); break;
           case 'vnc_start': this.subscribeToFrameUpdates(); break;
           case 'vnc_stop': this.dispose(); break;
           case 'mouse-event': case 'vnc_mouse_event':
@@ -487,7 +488,7 @@ export function handleWebSocketConnection(ws: WebSocket) {
   console.log("New WebSocket connection");
   addWebSocketConnection(ws);
   ws.send(JSON.stringify({ type: 'server_capabilities', protocolVersion: 1,
-    features: { agents: [], pty: false, vnc: true, vncSharedPort: true,
+    features: { agents: [], pty: false, vnc: true, vncSharedPort: true, heartbeat: true,
       vncStreamControl: true, vncTextInput: true } }));
 
   // Create a connection instance for this socket

--- a/extension/src/webview.ts
+++ b/extension/src/webview.ts
@@ -1,11 +1,12 @@
 import * as vscode from "vscode";
-import { getApiKey, saveApiKey } from "./ai/utils";
+import { getApiKey, getPairingToken, saveApiKey } from "./ai/utils";
 import { setWebviewPanel } from "./state/actions";
 import { handleChat } from "./ai/api";
 
 import { randomBytes } from "crypto";
 import { store } from "./state/store";
-import { connectionDetails } from "./connection";
+import * as QRCode from "qrcode";
+import { connectionDetails, pairingCode } from "./connection";
 
 function getWebviewContent(): string {
   const nonce = randomBytes(24).toString("hex");
@@ -135,10 +136,22 @@ function getWebviewContent(): string {
         <p>On your phone, select <strong>Tailscale / localhost (ws)</strong> for a direct connection.
         Connect Tailscale on both devices using the same account.</p>
         <div class="connection-actions">
+            <button data-action="showPairingQr">Show pairing QR</button>
             <button data-action="configureConnection">Choose connection</button>
             <button data-action="copyPairingToken">Copy pairing key</button>
             <button data-action="startServer">Start server</button>
             <button data-action="stopServer">Stop server</button>
+        </div>
+        <div id="pairingQrContainer" style="display: none; margin-top: 16px;">
+            <img id="pairingQr" alt="AirCodum pairing QR code" style="width: min(320px, 100%); height: auto; background: white; border-radius: 8px;">
+            <p>In AirCodum on your phone, tap <strong>Scan QR to connect</strong>. Requires AirCodum 2.4.1 or later.</p>
+            <button data-action="hidePairingQr">Hide QR code</button>
+        </div>
+        <div id="powerSettings" style="display: none; margin-top: 20px;">
+            <h2>Stay connected</h2>
+            <button data-action="toggleKeepAwake">Toggle Keep Mac awake</button>
+            <p id="powerStatus" aria-live="polite"></p>
+            <p>Keep Mac awake prevents idle sleep while the server runs. Closing the lid can still put macOS to sleep. For supported lid-closed operation, connect power, an external display, and a keyboard and mouse. AirCodum on your phone reconnects when the Mac is reachable again.</p>
         </div>
         <p>The pairing key is required in the phone’s connection settings. Copy it here and paste it on your phone.</p>
         <div>
@@ -178,7 +191,11 @@ function getWebviewContent(): string {
   
     <script nonce="${nonce}">
         const vscode = acquireVsCodeApi();
+        let connectionIdentity;
         const actions = { saveApiKey, copyToClipboard, addToCurrentFile, chat,
+          showPairingQr: () => vscode.postMessage({command: 'showPairingQr'}),
+          hidePairingQr: () => { document.getElementById('pairingQrContainer').style.display = 'none'; document.getElementById('pairingQr').removeAttribute('src'); },
+          toggleKeepAwake: () => vscode.postMessage({command: 'toggleKeepAwake'}),
           configureConnection: () => vscode.postMessage({command: 'configureConnection'}),
           copyPairingToken: () => vscode.postMessage({command: 'copyPairingToken'}),
           startServer: () => vscode.postMessage({command: 'startServer'}),
@@ -245,7 +262,19 @@ function getWebviewContent(): string {
                 case 'chatResponse':
                     handleChatResponseMessage(message);
                     break;
+                case 'power':
+                    document.getElementById('powerStatus').textContent = message.active ? 'Keep Mac awake is active while the server runs.' : 'Keep Mac awake is off or the server is stopped.';
+                    break;
+                case 'pairingQr':
+                    document.getElementById('pairingQr').src = message.dataUrl;
+                    document.getElementById('pairingQrContainer').style.display = 'block';
+                    document.getElementById('errorContainer').style.display = 'none';
+                    break;
                 case 'connection':
+                    const identity = JSON.stringify([message.host, message.port, message.running]);
+                    if (identity !== connectionIdentity) actions.hidePairingQr();
+                    connectionIdentity = identity;
+                    document.getElementById('powerSettings').style.display = message.mac ? 'block' : 'none';
                     document.getElementById('ipAddress').textContent = message.host;
                     document.getElementById('serverPort').textContent = String(message.port);
                     document.getElementById('serverState').textContent = message.running ? 'Running' : 'Stopped';
@@ -312,7 +341,7 @@ export function createWebviewPanel(
   const sendConnection = () => {
     const server = store.getState().server;
     const configured = vscode.workspace.getConfiguration("aircodum").get<string>("bindAddress", "127.0.0.1");
-    panel.webview.postMessage({ type: "connection", ...connectionDetails(server, configured) });
+    panel.webview.postMessage({ type: "connection", mac: process.platform === "darwin", ...connectionDetails(server, configured) });
   };
   const unsubscribe = store.subscribe(sendConnection);
 
@@ -333,9 +362,27 @@ export function createWebviewPanel(
         case "addToCurrentFile":
           addToCurrentFile(message.text);
           break;
+        case "toggleKeepAwake":
+          await vscode.commands.executeCommand('extension.toggleAirCodumKeepAwake');
+          break;
         case "connection":
           sendConnection();
+          await vscode.commands.executeCommand('extension.aircodumPowerStatus');
           break;
+        case "showPairingQr": {
+          try {
+            const server = store.getState().server;
+            const payload = pairingCode(server, await getPairingToken());
+            const dataUrl = await QRCode.toDataURL(payload, { width: 640, margin: 4, errorCorrectionLevel: 'M' });
+            const current = store.getState().server;
+            if (current.isRunning && current.address === server.address && current.port === server.port) {
+              panel.webview.postMessage({ type: "pairingQr", dataUrl });
+            }
+          } catch (error) {
+            panel.webview.postMessage({ type: "error", message: error instanceof Error ? error.message : "Unable to create pairing QR code." });
+          }
+          break;
+        }
         case "configureConnection":
           await vscode.commands.executeCommand("extension.configureAirCodumConnection");
           break;

--- a/extension/src/webview.ts
+++ b/extension/src/webview.ts
@@ -4,6 +4,8 @@ import { setWebviewPanel } from "./state/actions";
 import { handleChat } from "./ai/api";
 
 import { randomBytes } from "crypto";
+import { store } from "./state/store";
+import { connectionDetails } from "./connection";
 
 function getWebviewContent(): string {
   const nonce = randomBytes(24).toString("hex");
@@ -52,6 +54,10 @@ function getWebviewContent(): string {
             cursor: pointer;
             transition: background-color 0.3s ease;
         }
+        .connection-actions { display: flex; flex-wrap: wrap; gap: 8px; }
+        button:disabled { opacity: 0.5; cursor: default; }
+        button:focus-visible { outline: 2px solid var(--vscode-focusBorder, #569cd6); outline-offset: 2px; }
+        .status-value { overflow-wrap: anywhere; }
         button:hover {
             background-color: #1177bb;
         }
@@ -112,17 +118,29 @@ function getWebviewContent(): string {
         <div class="logo">AirCodum</div>
         <div class="tagline">Airdrop for your Code</div>
         
-        <div class="status">
+        <h2>Connect your phone</h2>
+        <div class="status" aria-live="polite">
+            <div class="status-item"><span>Server:</span><span id="serverState" class="status-value"></span></div>
             <div class="status-item">
-                <span>IP Address:</span>
+                <span>Host:</span>
                 <span id="ipAddress" class="status-value"></span>
             </div>
             <div class="status-item">
                 <span>Port:</span>
-                <span class="status-value">11040</span>
+                <span id="serverPort" class="status-value"></span>
             </div>
         </div>
         
+        <p id="connectionHint"></p>
+        <p>On your phone, select <strong>Tailscale / localhost (ws)</strong> for a direct connection.
+        Connect Tailscale on both devices using the same account.</p>
+        <div class="connection-actions">
+            <button data-action="configureConnection">Choose connection</button>
+            <button data-action="copyPairingToken">Copy pairing key</button>
+            <button data-action="startServer">Start server</button>
+            <button data-action="stopServer">Stop server</button>
+        </div>
+        <p>The pairing key is required in the phone’s connection settings. Copy it here and paste it on your phone.</p>
         <div>
             <h2>OpenAI API Key</h2>
             <input type="password" id="apiKeyInput" placeholder="Enter your OpenAI API key">
@@ -160,7 +178,12 @@ function getWebviewContent(): string {
   
     <script nonce="${nonce}">
         const vscode = acquireVsCodeApi();
-        const actions = { saveApiKey, copyToClipboard, addToCurrentFile, chat };
+        const actions = { saveApiKey, copyToClipboard, addToCurrentFile, chat,
+          configureConnection: () => vscode.postMessage({command: 'configureConnection'}),
+          copyPairingToken: () => vscode.postMessage({command: 'copyPairingToken'}),
+          startServer: () => vscode.postMessage({command: 'startServer'}),
+          stopServer: () => vscode.postMessage({command: 'stopServer'}),
+        };
         document.querySelectorAll('[data-action]').forEach(button => {
           button.addEventListener('click', () => actions[button.dataset.action](button.dataset.target));
         });
@@ -222,8 +245,13 @@ function getWebviewContent(): string {
                 case 'chatResponse':
                     handleChatResponseMessage(message);
                     break;
-                case 'ipAddress':
-                    document.getElementById('ipAddress').textContent = message.ipAddress;
+                case 'connection':
+                    document.getElementById('ipAddress').textContent = message.host;
+                    document.getElementById('serverPort').textContent = String(message.port);
+                    document.getElementById('serverState').textContent = message.running ? 'Running' : 'Stopped';
+                    document.getElementById('connectionHint').textContent = message.hint;
+                    document.querySelector('[data-action="startServer"]').disabled = message.running;
+                    document.querySelector('[data-action="stopServer"]').disabled = !message.running;
                     break;
                 case 'error':
                     showError(message.message);
@@ -258,16 +286,14 @@ function getWebviewContent(): string {
             document.querySelectorAll('#chatContainer button').forEach(btn => btn.style.display = 'inline-block');
         }
   
-        // Request the API key when the webview loads
-        vscode.postMessage({ command: 'ipAddress' });
+        vscode.postMessage({ command: 'connection' });
     </script>
   </body>
   </html>`;
 }
 
 export function createWebviewPanel(
-  context: vscode.ExtensionContext,
-  address: string
+  context: vscode.ExtensionContext
 ) {
   const panel = vscode.window.createWebviewPanel(
     "AirCodum",
@@ -283,12 +309,17 @@ export function createWebviewPanel(
   panel.webview.html = getWebviewContent();
 
 
-  // Send the IP address to the webview
-  panel.webview.postMessage({ type: "ipAddress", ipAddress: address });
+  const sendConnection = () => {
+    const server = store.getState().server;
+    const configured = vscode.workspace.getConfiguration("aircodum").get<string>("bindAddress", "127.0.0.1");
+    panel.webview.postMessage({ type: "connection", ...connectionDetails(server, configured) });
+  };
+  const unsubscribe = store.subscribe(sendConnection);
 
   // Add this event listener
   panel.onDidDispose(
     () => {
+      unsubscribe();
       setWebviewPanel(null);
     },
     null,
@@ -302,8 +333,20 @@ export function createWebviewPanel(
         case "addToCurrentFile":
           addToCurrentFile(message.text);
           break;
-        case "ipAddress":
-          panel?.webview.postMessage({ type: "ipAddress", ipAddress: address });
+        case "connection":
+          sendConnection();
+          break;
+        case "configureConnection":
+          await vscode.commands.executeCommand("extension.configureAirCodumConnection");
+          break;
+        case "copyPairingToken":
+          await vscode.commands.executeCommand("extension.copyAirCodumPairingToken");
+          break;
+        case "startServer":
+          await vscode.commands.executeCommand("extension.startAirCodumServer");
+          break;
+        case "stopServer":
+          await vscode.commands.executeCommand("extension.stopAirCodumServer");
           break;
         case "saveApiKey":
           await saveApiKey(message.key);

--- a/extension/tests/connection.test.cjs
+++ b/extension/tests/connection.test.cjs
@@ -1,0 +1,25 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { tailscaleAddresses, connectionDetails } = require('../src/connection.ts');
+
+test('connection choices contain detected Tailscale addresses, never public or LAN adapters', () => {
+  const address = (address, internal = false) => ({ address, internal });
+  assert.deepEqual(tailscaleAddresses({
+    lo: [address('127.0.0.1', true)],
+    en0: [address('192.168.1.2'), address('10.0.0.2'), address('8.8.8.8')],
+    utun: [address('100.89.59.102'), address('fd7a:115c:a1e0::1234')],
+    duplicate: [address('100.89.59.102')],
+  }), ['100.89.59.102']);
+  assert.deepEqual(tailscaleAddresses({}), []);
+});
+
+test('panel reports the actual listener until restarted, and explains local-only access', () => {
+  const server = { isRunning: true, address: '127.0.0.1', port: 11040 };
+  const active = connectionDetails(server, '100.89.59.102');
+  assert.equal(active.host, '127.0.0.1');
+  assert.match(active.hint, /only from this Mac/);
+  const stopped = connectionDetails({ ...server, isRunning: false }, '100.89.59.102');
+  assert.equal(stopped.host, '100.89.59.102');
+  assert.match(stopped.hint, /Server stopped/);
+  assert.equal(connectionDetails({ ...server, address: '100.89.59.102' }, '127.0.0.1').running, true);
+});

--- a/extension/tests/connection.test.cjs
+++ b/extension/tests/connection.test.cjs
@@ -23,3 +23,17 @@ test('panel reports the actual listener until restarted, and explains local-only
   assert.match(stopped.hint, /Server stopped/);
   assert.equal(connectionDetails({ ...server, address: '100.89.59.102' }, '127.0.0.1').running, true);
 });
+
+const { pairingCode } = require('../src/connection.ts');
+const QRCode = require('qrcode');
+const { PNG } = require('pngjs');
+const jsQR = require('jsqr');
+test('pairing image decodes to the complete versioned phone connection', async () => {
+ const token='a'.repeat(64);
+ const payload=pairingCode({isRunning:true,address:'100.89.59.102',port:11040},token);
+ const png=PNG.sync.read(await QRCode.toBuffer(payload,{width:640,margin:4,errorCorrectionLevel:'M'}));
+ const decoded=jsQR(new Uint8ClampedArray(png.data),png.width,png.height);
+ assert.equal(decoded.data,payload);
+ assert.deepEqual(JSON.parse(decoded.data),{type:'aircodum-pairing',version:1,host:'100.89.59.102',port:11040,tls:false,token});
+ for(const state of [{isRunning:false,address:'100.89.59.102',port:11040},{isRunning:true,address:'127.0.0.1',port:11040}]) assert.throws(()=>pairingCode(state,token));
+});

--- a/extension/tests/keep-awake.test.cjs
+++ b/extension/tests/keep-awake.test.cjs
@@ -1,0 +1,13 @@
+const {test}=require('node:test');const assert=require('node:assert/strict');const {EventEmitter}=require('node:events');const Module=require('node:module');
+const calls=[];const original=Module._load;let child;
+Module._load=function(name,...rest){if(name==='child_process')return {spawn:(file,args,options)=>{calls.push({file,args,options});child=new EventEmitter();child.pid=123;child.kill=()=>{child.killed=true};return child;}};return original.call(this,name,...rest);};
+const {KeepAwake}=require('../src/keep-awake.ts');Module._load=original;
+test('awake assertion is opted in, scoped to the extension PID and released when server stops',()=>{
+ let changes=0;const awake=new KeepAwake(()=>changes++,()=>{});
+ awake.update(false,true);awake.update(true,false);assert.equal(calls.length,0);
+ awake.update(true,true);
+ if(process.platform!=='darwin'){assert.equal(calls.length,0);return;}
+ assert.deepEqual(calls[0],{file:'/usr/bin/caffeinate',args:['-is','-w',String(process.pid)],options:{stdio:'ignore'}});
+ awake.update(true,true);assert.equal(calls.length,1);assert.equal(awake.active,true);
+ child.emit('spawn');assert.equal(changes,1);awake.update(true,false);assert.equal(child.killed,true);assert.equal(awake.active,false);
+});

--- a/extension/tests/server.test.cjs
+++ b/extension/tests/server.test.cjs
@@ -23,6 +23,11 @@ const message = socket => once(socket, 'message').then(([data]) => JSON.parse(da
 test('extension requires pairing, streams only on demand, rejects malformed text and releases listener', async () => {
   store.setState({ server: { port: 0, isRunning: false, address: null } });
   await assert.rejects(startServer('0.0.0.0', token));
+  const occupied = require('net').createServer(); occupied.listen(0, '127.0.0.1'); await once(occupied, 'listening');
+  store.setState({ server: { port: occupied.address().port, isRunning: false, address: null } });
+  await assert.rejects(startServer('127.0.0.1', token), /EADDRINUSE/);
+  await new Promise(resolve => occupied.close(resolve));
+  store.setState({ server: { port: 0, isRunning: false, address: null } });
   await startServer('127.0.0.1', token);
   const wss = store.getState().websocket.wss;
   const port = wss.address().port;
@@ -40,6 +45,9 @@ test('extension requires pairing, streams only on demand, rejects malformed text
     assert.equal(capabilities.features.pty, false);
     assert.deepEqual(capabilities.features.agents, []);
     assert.equal(captures, 0);
+    assert.equal(capabilities.features.heartbeat, true);
+    const pong = message(client); client.send(JSON.stringify({type: 'ping'}));
+    assert.equal((await pong).type, 'pong');
     const rejected = message(client); client.send('{broken');
     assert.equal((await rejected).type, 'error'); assert.equal(uploads, 0);
     const frame = message(client); client.send(JSON.stringify({ type: 'vnc_start' }));


### PR DESCRIPTION
AirCodum required copying the desktop host, port and pairing key by hand, and idle sleep or stale sockets could interrupt remote access.

Extension 0.2.3 adds optional locally generated QR pairing for Android/iOS AirCodum 2.4.1. Manual host/port settings, TLS/Tailscale connections and Copy pairing key remain available. QR visibility follows listener changes. A Keep Mac awake control holds a process-scoped macOS assertion while the server runs; the UI explains that lid-close sleep still requires a supported powered external-display setup. Negotiated application heartbeats and WebSocket ping/pong cleanup support reconnection after sleep or network changes. An occupied port now fails cleanly without an unhandled WebSocket-server error.

Validation: TypeScript and 10 regression tests pass, including decoding the rendered QR image, native input/authentication compatibility, port conflicts and keep-awake lifecycle. The final packaged VSIX ran in isolated VS Code: authenticated connection, pairing key copy, native caffeinate assertion, stop/start and QR display passed. The user's existing connection was retained. Physical lid-close behavior was not exercised.

Mobile companion: priyankark/AirCodum-Mobile branch fix/qr-pairing, version 2.4.1, Android build 30 and iOS build 33.

Published to the VS Code Marketplace as 0.2.3. Public latest-version catalog and downloaded VSIX SHA-256 match the tested artifact (`b8b570de1fd6f732fbbc29fce63d56547933c971daf9130eebad225b8856305e`). Installed locally for the next reload.
