### PR TITLE
Simplify extension pairing, settings and AI navigation

### DIFF
--- a/CONNECTION_SETUP.md
+++ b/CONNECTION_SETUP.md
@@ -1,3 +1,7 @@
+## Connect from the extension UI (0.2.2)
+
+Open **AirCodum** using **Open AirCodum Webview**. Under **Connect your phone**, use **Choose connection** and select the detected Tailscale address. This saves the address and starts the listener there. Connect Tailscale on both devices with the same account. Enter the displayed host and port in the phone app, choose **Tailscale / localhost (ws)**, and use **Copy pairing key** to transfer the key. The UI reports the active listener, even if the saved setting changes before restart. Start and stop controls remain available in the panel.
+
 # Connecting AirCodum to VS Code
 
 Use [AirCodum-Mobile](https://github.com/priyankark/AirCodum-Mobile), package `com.codeair`, with this extension. [AirCodum-Agnentum-Mobile](https://github.com/priyankark/AirCodum-Agnentum-Mobile) is the separate app for Agentum CLI.

--- a/CONNECTION_SETUP.md
+++ b/CONNECTION_SETUP.md
@@ -21,3 +21,11 @@ Send inserts the local text draft; Enter presses a separate desktop key. Leaving
 Validation commands: `npm run compile` and `npm run test:security` in the extension; `npx tsc --noEmit` and `npm run test:security` in the original mobile repo. See [NATIVE_VALIDATION.md](NATIVE_VALIDATION.md) for real VS Code and Android testing.
 
 The separate Agentum stack uses ports 11042/11043 and its own pairing credential. Its setup belongs to the [Agentum CLI PR](https://github.com/priyankark/agentum-cli/pull/3).
+
+## QR and sleep recovery (extension 0.2.3 / mobile 2.4.1)
+
+QR is optional; manual TLS/Tailscale host, port and token entry remains supported. QR images are generated locally and hidden when the listener changes. Both mobile platforms validate the payload, store the credential in SecureStore and use the existing authenticated handshake.
+
+Keep Mac awake holds a process-scoped macOS power assertion only while the server runs; stop, disable, or exit releases it. It changes no global power preferences. Lid closure can still force sleep. Apple-supported closed-display operation needs power, an external display, and keyboard/mouse. This extension cannot serve requests while the OS is asleep. Mobile retries continue with capped backoff while active, recover on foreground, and stop after Disconnect or authentication rejection.
+
+References: https://developer.apple.com/documentation/iokit/kiopmassertiontypepreventuseridlesystemsleep and https://support.apple.com/en-us/117373

--- a/NATIVE_VALIDATION.md
+++ b/NATIVE_VALIDATION.md
@@ -61,3 +61,8 @@ JavaScript and all native modules, is byte-identical. This promotion does not
 represent another native mobile E2E run; the runtime coverage above applies.
 
 GA VSIX SHA-256: `831d840500ab6c07b862296f223490f8e8f5a2824a05ff3e4cb748f20d099cf6`.
+
+The public Marketplace catalog confirmed 0.2.1 without the PreRelease property.
+The downloaded Marketplace package matched the GA SHA-256 after HTTP gzip
+decoding. A fresh isolated VS Code 1.121.0 profile installed
+`priyankark.aircodum-app` as 0.2.1 without `--pre-release` or a pinned version.

--- a/NATIVE_VALIDATION.md
+++ b/NATIVE_VALIDATION.md
@@ -47,3 +47,17 @@ Android used a universal emulator APK derived from the production AirCodum-Mobil
 The opt-in host setting `AIRCODUM_E2E_FOCUS_HOLD_MS=10000` keeps only its isolated VS Code process in front for up to ten seconds after focus requests during automation. Keep macOS awake and reserve the desktop for these tests. Mobile drivers also wake Android, reject stale UI hierarchies and pace native XCTest typing. These test-driver changes do not change the released extension runtime.
 
 VSIX SHA-256: `2817f4d109d8edd58c9819c77bf6c0e0e2105dc1da070e62c3d07ef893167c9e`. Full release/build/submission status is tracked in AirCodum-Mobile's STORE_RELEASE.md. Physical devices, production TLS/Tailscale, Windows/Linux and camera/file-picker/voice/AI flows remain outside this validation.
+
+## GA promotion — September 10, 2026
+
+Version 0.2.1 promotes the tested 0.2.0 runtime to the stable Marketplace channel
+after iOS AirCodum 2.4.0 reached READY_FOR_SALE. Android build 28 remains in review.
+Marketplace requires different version numbers for pre-release and stable builds.
+The GA VSIX was made from the verified original VSIX, preserving each ZIP entry's
+metadata and bytes except `extension/package.json` (version 0.2.0 → 0.2.1) and
+`extension.vsixmanifest` (version increment and removal of PreRelease=true).
+Comparison of all 14 entries confirmed that every runtime file, including bundled
+JavaScript and all native modules, is byte-identical. This promotion does not
+represent another native mobile E2E run; the runtime coverage above applies.
+
+GA VSIX SHA-256: `831d840500ab6c07b862296f223490f8e8f5a2824a05ff3e4cb748f20d099cf6`.

--- a/REVIEW_SETUP.md
+++ b/REVIEW_SETUP.md
@@ -13,17 +13,16 @@ registration, or one-time login code. Desktop setup is required.
 - [AirCodum: Control VS Code right from your phone!](https://youtu.be/HXtH_NYY2Lc)
   — the demo linked in the extension documentation.
 
-The steps below describe the current 2.4.0 app / 0.2.0 extension pairing process.
+The steps below describe the current 2.4.0 app / 0.2.1 extension pairing process.
 
 ## Install the published extension
 
 1. Install [Visual Studio Code](https://code.visualstudio.com/) on a computer.
 2. Open Extensions and search for `priyankark.aircodum-app`, or open its
    [published Marketplace page](https://marketplace.visualstudio.com/items?itemName=priyankark.aircodum-app).
-3. Select **Install Pre-Release Version**, or **Switch to Pre-Release Version**
-   if already installed. Confirm extension version **0.2.0**. The stable channel
-   remains 0.1.11 and does not provide the new pairing commands.
-   Alternatively, install the [published 0.2.0 VSIX](https://github.com/priyankark/AirCodum/releases/tag/v0.2.0)
+3. Select **Install** or update the extension. Confirm stable version **0.2.1**.
+   If using the pre-release channel, **Switch to Release Version** is also available.
+   Alternatively, install the [published 0.2.1 VSIX](https://github.com/priyankark/AirCodum/releases/tag/v0.2.1)
    using **Extensions: Install from VSIX**.
 4. Open a disposable folder in VS Code and trust that folder. Create and open
    `review.txt` containing sample text. Keep VS Code and that editor in front

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.2.2
+
+- Added connection controls showing the active host, port, and server status.
+- Added Copy pairing key and a detected Tailscale address selector.
+- Keep connection controls available when the server stops or fails to start.
+- Explain when localhost cannot be reached directly from a phone.
+
 # Changelog
 
 ## 0.2.0 (pre-release)

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.3
+
+- Added QR pairing with AirCodum mobile 2.4.1; manual connection controls remain available.
+- Added Keep Mac awake while the server runs, with guidance for supported closed-display use.
+- Added heartbeat support and removal of stale connections after sleep or network interruption.
+
 ## 0.2.2
 
 - Added connection controls showing the active host, port, and server status.

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,4 +1,10 @@
-## 0.2.4 (unreleased)
+## 0.2.5
+
+- Reorganized the panel into Connection and Files & AI, with QR/manual pairing tabs and one main connection action.
+- Grouped address, server, keep-awake and troubleshooting controls in a collapsible settings section.
+- Added active connection status, accessible keyboard navigation, and responsive styling that follows the VS Code theme.
+- Kept optional AI setup out of phone pairing.
+
 
 - Added AirCodum Connections output logs for pairing failures, TLS mismatches and disconnect codes. Pairing keys and message contents are excluded.
 

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.4 (unreleased)
+
+- Added AirCodum Connections output logs for pairing failures, TLS mismatches and disconnect codes. Pairing keys and message contents are excluded.
+
 ## 0.2.3
 
 - Added QR pairing with AirCodum mobile 2.4.1; manual connection controls remain available.

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,3 +1,7 @@
+## Connect your phone
+
+Open **AirCodum Webview** and use **Choose connection** to select the Mac’s Tailscale address. The panel shows the active host, port, and server status. Use **Copy pairing key** and paste the key in the mobile connection settings. Start and stop the listener from the same panel.
+
 # AirCodum: Smartphone powered Remote Control for VS Code
 
 ## Table of Contents

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,12 +1,12 @@
 ## Scan to connect
 
-With AirCodum mobile 2.4.1 or later, choose your Tailscale connection in this extension and click **Show pairing QR**. Tap **Scan QR to connect** on Android or iOS. The scan fills host, port, transport and pairing key and connects. Manual connection and Copy pairing key remain available.
+With AirCodum mobile 2.4.1 or later, choose your Tailscale connection in this extension and open **Connection → QR code → Show QR code**. Tap **Scan QR to connect** on Android or iOS. The scan fills host, port, transport and pairing key and connects. Use **Enter manually** for host, port, connection method, and **Copy pairing key**.
 
 **Keep Mac awake** prevents idle sleep while the server is running. It does not override macOS lid-close sleep. For supported closed-display use, connect power, an external display, and a keyboard and mouse. The mobile app retries when the desktop becomes reachable again.
 
 ## Connect your phone
 
-Open **AirCodum Webview** and use **Choose connection** to select the Mac’s Tailscale address. The panel shows the active host, port, and server status. Use **Copy pairing key** and paste the key in the mobile connection settings. Start and stop the listener from the same panel.
+Open **AirCodum Webview**. The **Connection** tab shows the server address and connection status, with **QR code** and **Enter manually** pairing options. Expand **Server settings & troubleshooting** to change the connection address, start or stop the server, set **Keep Mac awake**, or open the connection log. The **Files & AI** tab holds received content and the optional AI assistant.
 
 # AirCodum: Smartphone powered Remote Control for VS Code
 
@@ -52,8 +52,8 @@ Check out this demo to understand how to use AirCodum: [AirCodum YouTube Demo](h
 1. Obtain an API key from OpenAI (https://openai.com/)
 2. In VS Code, open the Command Palette (Ctrl+Shift+P or Cmd+Shift+P)
 3. Type "AirCodum: Open Webview" and select it
-4. In the AirCodum interface, enter your API key in the "OpenAI API Key" field
-5. Click "Save Key"
+4. Open **Files & AI → AI assistant → Set up AI**, then enter your API key.
+5. Click **Save key**. An API key is optional and is not needed for phone pairing.
 
 ### Pairing and transport
 
@@ -111,7 +111,7 @@ VNC Mode allows you to control VS Code directly through your smartphone's screen
 
 ### Using AI Chat
 
-1. In the AirCodum interface, find the "Chat with AI" section
+1. In the AirCodum interface, open **Files & AI → AI assistant**
 2. Type your question or request related to the recently sent files.
 3. Click "Send" or press Enter
 4. View the AI's response in the interface

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,3 +1,9 @@
+## Scan to connect
+
+With AirCodum mobile 2.4.1 or later, choose your Tailscale connection in this extension and click **Show pairing QR**. Tap **Scan QR to connect** on Android or iOS. The scan fills host, port, transport and pairing key and connects. Manual connection and Copy pairing key remain available.
+
+**Keep Mac awake** prevents idle sleep while the server is running. It does not override macOS lid-close sleep. For supported closed-display use, connect power, an external display, and a keyboard and mouse. The mobile app retries when the desktop becomes reachable again.
+
 ## Connect your phone
 
 Open **AirCodum Webview** and use **Choose connection** to select the Mac’s Tailscale address. The panel shows the active host, port, and server status. Use **Copy pairing key** and paste the key in the mobile connection settings. Start and stop the listener from the same panel.

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aircodum-app",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aircodum-app",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
         "@hurdlegroup/robotjs": "^0.12.2",
         "@types/node-fetch": "^2.6.11",

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aircodum-app",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aircodum-app",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
         "@hurdlegroup/robotjs": "^0.12.2",
         "@types/node-fetch": "^2.6.11",

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aircodum-app",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aircodum-app",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@hurdlegroup/robotjs": "^0.12.2",
         "@types/node-fetch": "^2.6.11",

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aircodum-app",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aircodum-app",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@hurdlegroup/robotjs": "^0.12.2",
         "@types/node-fetch": "^2.6.11",
@@ -18,18 +18,21 @@
         "node-fetch": "^2.7.0",
         "node-webp": "^1.0.2",
         "openai": "^4.67.0",
+        "qrcode": "^1.5.4",
         "screenshot-desktop": "^1.15.2",
         "ws": "^8.18.0"
       },
       "devDependencies": {
         "@types/jimp": "^0.2.1",
         "@types/node": "^18",
+        "@types/qrcode": "^1.5.6",
         "@types/vscode": "^1.73.0",
         "@types/ws": "^8.5.12",
         "@typescript-eslint/eslint-plugin": "^7.14.0",
         "@typescript-eslint/parser": "^7.14.0",
         "esbuild": "^0.25.0",
         "eslint": "^8.26.0",
+        "jsqr": "^1.4.0",
         "npm-run-all": "^4.1.5",
         "typescript": "^5.5.2"
       },
@@ -1072,6 +1075,16 @@
         "form-data": "^4.0.0"
       }
     },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/screenshot-desktop": {
       "version": "1.12.3",
       "resolved": "https://registry.npmjs.org/@types/screenshot-desktop/-/screenshot-desktop-1.12.3.tgz",
@@ -1380,7 +1393,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -1389,7 +1401,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -1581,6 +1592,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1597,11 +1617,21 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -1612,8 +1642,7 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -1718,6 +1747,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1768,6 +1806,12 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -1832,6 +1876,12 @@
       "funding": {
         "url": "https://bevry.me/fund"
       }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/encoding": {
       "version": "0.1.13",
@@ -2419,6 +2469,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -2923,6 +2982,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -3203,6 +3271,13 @@
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "node_modules/jsqr": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsqr/-/jsqr-1.4.0.tgz",
+      "integrity": "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -3773,6 +3848,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -3831,7 +3915,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3963,6 +4046,32 @@
         "node": ">=6"
       }
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -4029,6 +4138,21 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -4186,6 +4310,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -4327,6 +4457,20 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string.prototype.padend": {
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.6.tgz",
@@ -4402,7 +4546,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -4828,6 +4971,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
@@ -4855,6 +5004,20 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {
@@ -4909,6 +5072,99 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {
@@ -5550,6 +5806,15 @@
         "form-data": "^4.0.0"
       }
     },
+    "@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/screenshot-desktop": {
       "version": "1.12.3",
       "resolved": "https://registry.npmjs.org/@types/screenshot-desktop/-/screenshot-desktop-1.12.3.tgz",
@@ -5739,14 +6004,12 @@
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
       }
@@ -5877,6 +6140,11 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+    },
     "chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -5887,11 +6155,20 @@
         "supports-color": "^7.1.0"
       }
     },
+    "cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
@@ -5899,8 +6176,7 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -5967,6 +6243,11 @@
         "ms": "^2.1.3"
       }
     },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
+    },
     "deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -5999,6 +6280,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+    },
+    "dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA=="
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -6040,6 +6326,11 @@
       "requires": {
         "version-range": "^4.13.0"
       }
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "encoding": {
       "version": "0.1.13",
@@ -6485,6 +6776,11 @@
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true
     },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+    },
     "get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -6815,6 +7111,11 @@
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+    },
     "is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -7002,6 +7303,12 @@
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       }
+    },
+    "jsqr": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsqr/-/jsqr-1.4.0.tgz",
+      "integrity": "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==",
+      "dev": true
     },
     "levn": {
       "version": "0.4.1",
@@ -7378,6 +7685,11 @@
         "p-limit": "^3.0.2"
       }
     },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+    },
     "pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -7424,8 +7736,7 @@
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -7506,6 +7817,23 @@
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true
     },
+    "qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "requires": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "dependencies": {
+        "pngjs": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+          "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="
+        }
+      }
+    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -7545,6 +7873,16 @@
         "es-errors": "^1.3.0",
         "set-function-name": "^2.0.2"
       }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "resolve": {
       "version": "1.22.8",
@@ -7635,6 +7973,11 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
     "set-function-length": {
       "version": "1.2.2",
@@ -7738,6 +8081,16 @@
       "integrity": "sha512-jg25NiDV/1fLtSgEgyvVyDunvaNHbuwF9lfNV17gSmPFAlYzdfNBlLtLzXTevwkPj7DhGbmN9VnmJIgLnhvaBw==",
       "dev": true
     },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
     "string.prototype.padend": {
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.6.tgz",
@@ -7788,7 +8141,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }
@@ -8070,6 +8422,11 @@
         "is-symbol": "^1.0.3"
       }
     },
+    "which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="
+    },
     "which-typed-array": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
@@ -8088,6 +8445,16 @@
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true
+    },
+    "wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
     },
     "wrappy": {
       "version": "1.0.2",
@@ -8118,6 +8485,73 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+    },
+    "y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+    },
+    "yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "requires": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aircodum-app",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aircodum-app",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@hurdlegroup/robotjs": "^0.12.2",
         "@types/node-fetch": "^2.6.11",

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "aircodum-app",
   "displayName": "AirCodum: Smartphone based Remote Control for VS Code",
   "description": "Smartphone based Remote Control for VS Code. Control IDE actions, send files and images, get AI assistance and more, right from your smartphone.",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "publisher": "priyankark",
   "repository": "https://github.com/priyankark/AirCodum",
   "engines": {
@@ -39,6 +39,10 @@
       {
         "command": "extension.configureAirCodumConnection",
         "title": "AirCodum: Choose Connection"
+      },
+      {
+        "command": "extension.toggleAirCodumKeepAwake",
+        "title": "AirCodum: Toggle Keep Mac Awake"
       }
     ],
     "configuration": {
@@ -49,6 +53,12 @@
           "default": "127.0.0.1",
           "scope": "application",
           "description": "Listen address. For remote access, use your encrypted VPN interface address or a TLS proxy."
+        },
+        "aircodum.keepAwake": {
+          "type": "boolean",
+          "default": false,
+          "scope": "application",
+          "description": "On macOS, prevent idle sleep while the AirCodum server runs. Does not override lid-close sleep; supported closed-display use requires power and an external display."
         }
       }
     }
@@ -66,12 +76,14 @@
   "devDependencies": {
     "@types/jimp": "^0.2.1",
     "@types/node": "^18",
+    "@types/qrcode": "^1.5.6",
     "@types/vscode": "^1.73.0",
     "@types/ws": "^8.5.12",
     "@typescript-eslint/eslint-plugin": "^7.14.0",
     "@typescript-eslint/parser": "^7.14.0",
     "esbuild": "^0.25.0",
     "eslint": "^8.26.0",
+    "jsqr": "^1.4.0",
     "npm-run-all": "^4.1.5",
     "typescript": "^5.5.2"
   },
@@ -86,6 +98,7 @@
     "node-fetch": "^2.7.0",
     "node-webp": "^1.0.2",
     "openai": "^4.67.0",
+    "qrcode": "^1.5.4",
     "screenshot-desktop": "^1.15.2",
     "ws": "^8.18.0"
   },

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "aircodum-app",
   "displayName": "AirCodum: Smartphone based Remote Control for VS Code",
   "description": "Smartphone based Remote Control for VS Code. Control IDE actions, send files and images, get AI assistance and more, right from your smartphone.",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "publisher": "priyankark",
   "repository": "https://github.com/priyankark/AirCodum",
   "engines": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "aircodum-app",
   "displayName": "AirCodum: Smartphone based Remote Control for VS Code",
   "description": "Smartphone based Remote Control for VS Code. Control IDE actions, send files and images, get AI assistance and more, right from your smartphone.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "publisher": "priyankark",
   "repository": "https://github.com/priyankark/AirCodum",
   "engines": {
@@ -35,6 +35,10 @@
       {
         "command": "extension.copyAirCodumPairingToken",
         "title": "AirCodum: Copy Pairing Token"
+      },
+      {
+        "command": "extension.configureAirCodumConnection",
+        "title": "AirCodum: Choose Connection"
       }
     ],
     "configuration": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "aircodum-app",
   "displayName": "AirCodum: Smartphone based Remote Control for VS Code",
   "description": "Smartphone based Remote Control for VS Code. Control IDE actions, send files and images, get AI assistance and more, right from your smartphone.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "publisher": "priyankark",
   "repository": "https://github.com/priyankark/AirCodum",
   "engines": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "aircodum-app",
   "displayName": "AirCodum: Smartphone based Remote Control for VS Code",
   "description": "Smartphone based Remote Control for VS Code. Control IDE actions, send files and images, get AI assistance and more, right from your smartphone.",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "publisher": "priyankark",
   "repository": "https://github.com/priyankark/AirCodum",
   "engines": {

--- a/extension/src/connection-log.ts
+++ b/extension/src/connection-log.ts
@@ -7,6 +7,8 @@ export function initializeConnectionLog(context: vscode.ExtensionContext) {
   context.subscriptions.push(output);
 }
 
+export function showConnectionLog() { output?.show(true); }
+
 /** Only pass fixed event descriptions, network addresses and numeric close codes. */
 export function connectionLog(event: string) {
   try { output?.appendLine(`${new Date().toISOString()} ${event}`); } catch { /* Logging must not interrupt a connection. */ }

--- a/extension/src/connection-log.ts
+++ b/extension/src/connection-log.ts
@@ -1,0 +1,13 @@
+import * as vscode from 'vscode';
+
+let output: vscode.OutputChannel | undefined;
+
+export function initializeConnectionLog(context: vscode.ExtensionContext) {
+  output = vscode.window.createOutputChannel('AirCodum Connections');
+  context.subscriptions.push(output);
+}
+
+/** Only pass fixed event descriptions, network addresses and numeric close codes. */
+export function connectionLog(event: string) {
+  try { output?.appendLine(`${new Date().toISOString()} ${event}`); } catch { /* Logging must not interrupt a connection. */ }
+}

--- a/extension/src/connection.ts
+++ b/extension/src/connection.ts
@@ -1,0 +1,19 @@
+import type { NetworkInterfaceInfo } from "os";
+import { protectedBind } from "./security";
+
+export function tailscaleAddresses(interfaces: NodeJS.Dict<NetworkInterfaceInfo[]>): string[] {
+  return [...new Set(Object.values(interfaces).flatMap(entries => entries ?? [])
+    .filter(entry => !entry.internal && !entry.address.includes(":") && protectedBind(entry.address))
+    .map(entry => entry.address))].sort();
+}
+
+export function connectionDetails(server: { isRunning: boolean; address: string | null; port: number }, configured: string) {
+  const host = server.isRunning && server.address ? server.address : configured;
+  const local = host === "localhost" || host === "::1" || host.startsWith("127.");
+  return {
+    host, port: server.port, running: server.isRunning,
+    hint: !server.isRunning ? "Server stopped. Start it to connect your phone." : local
+      ? "This address is reachable only from this Mac. Choose connection → Tailscale to connect your phone directly."
+      : "Enter this host and port on your phone, then paste the pairing key.",
+  };
+}

--- a/extension/src/connection.ts
+++ b/extension/src/connection.ts
@@ -4,7 +4,7 @@ import { protectedBind } from "./security";
 export function tailscaleAddresses(interfaces: NodeJS.Dict<NetworkInterfaceInfo[]>): string[] {
   return [...new Set(Object.values(interfaces).flatMap(entries => entries ?? [])
     .filter(entry => !entry.internal && !entry.address.includes(":") && protectedBind(entry.address))
-    .map(entry => entry.address))].sort();
+    .map(entry => entry.address))].sort((a, b) => Number(a.includes(":")) - Number(b.includes(":")) || a.localeCompare(b));
 }
 
 export function connectionDetails(server: { isRunning: boolean; address: string | null; port: number }, configured: string) {
@@ -16,4 +16,14 @@ export function connectionDetails(server: { isRunning: boolean; address: string 
       ? "This address is reachable only from this Mac. Choose connection → Tailscale to connect your phone directly."
       : "Enter this host and port on your phone, then paste the pairing key.",
   };
+}
+
+export function pairingCode(server: { isRunning: boolean; address: string | null; port: number }, token: string): string {
+  if (!server.isRunning || !server.address) throw new Error('Start the server before showing a pairing code.');
+  const host = server.address;
+  if (host === 'localhost' || host === '::1' || host.startsWith('127.')) {
+    throw new Error('Choose connection → Tailscale first so your phone can reach this Mac.');
+  }
+  if (!protectedBind(host) || !/^[a-zA-Z0-9_-]{32,256}$/.test(token)) throw new Error('Invalid pairing settings.');
+  return JSON.stringify({ type: 'aircodum-pairing', version: 1, host: host.includes(':') ? `[${host}]` : host, port: server.port, tls: false, token });
 }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -19,30 +19,48 @@
 import * as vscode from "vscode";
 import { initializeSecrets, getPairingToken } from "./ai/utils";
 import { store } from "./state/store";
-import {
-  setServerAddress,
-  setServerRunning,
-} from "./state/actions";
 import { startServer, stopServer } from "./server";
 import { createWebviewPanel } from "./webview";
+import { networkInterfaces } from "os";
+import { tailscaleAddresses } from "./connection";
 
 export async function activate(context: vscode.ExtensionContext) {
   await initializeSecrets(context);
 
-  const startServerAndWebview = async () => {
-    if (store.getState().server.isRunning) {
-      vscode.window.showInformationMessage(
-        "AirCodum server is already running."
-      );
-      return;
-    }
-
-    const address = vscode.workspace.getConfiguration("aircodum").get<string>("bindAddress", "127.0.0.1");
-    await startServer(address, await getPairingToken());
-    setServerRunning(true);
-    setServerAddress(address);
-    createWebviewPanel(context, address);
+  const showPanel = () => {
+    const { webview } = store.getState();
+    if (webview.panel) webview.panel.reveal();
+    else createWebviewPanel(context);
   };
+
+  const startServerAndWebview = async () => {
+    showPanel();
+    if (store.getState().server.isRunning) return;
+    try {
+      const address = vscode.workspace.getConfiguration("aircodum").get<string>("bindAddress", "127.0.0.1");
+      await startServer(address, await getPairingToken());
+    } catch (error) {
+      vscode.window.showErrorMessage(`AirCodum could not start: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  };
+
+  context.subscriptions.push(vscode.commands.registerCommand("extension.configureAirCodumConnection", async () => {
+    const addresses = tailscaleAddresses(networkInterfaces());
+    const choices = addresses.map(address => ({ label: "Tailscale", description: address, address }));
+    choices.push({ label: "Localhost", description: "This Mac only, or a local TLS proxy", address: "127.0.0.1" });
+    const choice = await vscode.window.showQuickPick(choices, {
+      title: "AirCodum connection",
+      placeHolder: addresses.length ? "Choose the address your phone will connect to" : "No Tailscale address found. Connect Tailscale on this Mac, then try again.",
+    });
+    if (!choice) return;
+    try {
+      await vscode.workspace.getConfiguration("aircodum").update("bindAddress", choice.address, vscode.ConfigurationTarget.Global);
+      stopServer();
+      await startServerAndWebview();
+    } catch (error) {
+      vscode.window.showErrorMessage(`AirCodum connection failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }));
 
   const startServerCommand = vscode.commands.registerCommand(
     "extension.startAirCodumServer",
@@ -59,7 +77,7 @@ export async function activate(context: vscode.ExtensionContext) {
         if (!server.isRunning) {
           await startServerAndWebview();
         } else {
-          createWebviewPanel(context, server.address!);
+          createWebviewPanel(context);
         }
       }
     }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -24,8 +24,10 @@ import { createWebviewPanel } from "./webview";
 import { KeepAwake } from "./keep-awake";
 import { networkInterfaces } from "os";
 import { tailscaleAddresses } from "./connection";
+import { initializeConnectionLog } from './connection-log';
 
 export async function activate(context: vscode.ExtensionContext) {
+  initializeConnectionLog(context);
   await initializeSecrets(context);
   const updatePowerStatus = () => store.getState().webview.panel?.webview.postMessage({ type: 'power', active: keepAwake.active });
   const keepAwake = new KeepAwake(updatePowerStatus, message => { vscode.window.showErrorMessage(message); });

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -29,12 +29,12 @@ import { initializeConnectionLog } from './connection-log';
 export async function activate(context: vscode.ExtensionContext) {
   initializeConnectionLog(context);
   await initializeSecrets(context);
-  const updatePowerStatus = () => store.getState().webview.panel?.webview.postMessage({ type: 'power', active: keepAwake.active });
+  const updatePowerStatus = () => store.getState().webview.panel?.webview.postMessage({ type: 'power', active: keepAwake.active, enabled: vscode.workspace.getConfiguration('aircodum').get<boolean>('keepAwake', false) });
   const keepAwake = new KeepAwake(updatePowerStatus, message => { vscode.window.showErrorMessage(message); });
   const syncPower = () => keepAwake.update(vscode.workspace.getConfiguration('aircodum').get<boolean>('keepAwake', false), store.getState().server.isRunning);
   const unsubscribePower = store.subscribe(syncPower);
   context.subscriptions.push({ dispose: () => { unsubscribePower(); keepAwake.stop(); } });
-  context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(event => { if (event.affectsConfiguration('aircodum.keepAwake')) syncPower(); }));
+  context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(event => { if (event.affectsConfiguration('aircodum.keepAwake')) { syncPower(); updatePowerStatus(); } }));
   context.subscriptions.push(vscode.commands.registerCommand('extension.toggleAirCodumKeepAwake', async () => {
     const config = vscode.workspace.getConfiguration('aircodum');
     await config.update('keepAwake', !config.get<boolean>('keepAwake', false), vscode.ConfigurationTarget.Global);

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -21,11 +21,24 @@ import { initializeSecrets, getPairingToken } from "./ai/utils";
 import { store } from "./state/store";
 import { startServer, stopServer } from "./server";
 import { createWebviewPanel } from "./webview";
+import { KeepAwake } from "./keep-awake";
 import { networkInterfaces } from "os";
 import { tailscaleAddresses } from "./connection";
 
 export async function activate(context: vscode.ExtensionContext) {
   await initializeSecrets(context);
+  const updatePowerStatus = () => store.getState().webview.panel?.webview.postMessage({ type: 'power', active: keepAwake.active });
+  const keepAwake = new KeepAwake(updatePowerStatus, message => { vscode.window.showErrorMessage(message); });
+  const syncPower = () => keepAwake.update(vscode.workspace.getConfiguration('aircodum').get<boolean>('keepAwake', false), store.getState().server.isRunning);
+  const unsubscribePower = store.subscribe(syncPower);
+  context.subscriptions.push({ dispose: () => { unsubscribePower(); keepAwake.stop(); } });
+  context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(event => { if (event.affectsConfiguration('aircodum.keepAwake')) syncPower(); }));
+  context.subscriptions.push(vscode.commands.registerCommand('extension.toggleAirCodumKeepAwake', async () => {
+    const config = vscode.workspace.getConfiguration('aircodum');
+    await config.update('keepAwake', !config.get<boolean>('keepAwake', false), vscode.ConfigurationTarget.Global);
+    syncPower(); updatePowerStatus();
+  }));
+  context.subscriptions.push(vscode.commands.registerCommand('extension.aircodumPowerStatus', updatePowerStatus));
 
   const showPanel = () => {
     const { webview } = store.getState();

--- a/extension/src/keep-awake.ts
+++ b/extension/src/keep-awake.ts
@@ -1,0 +1,26 @@
+import { ChildProcess, spawn } from 'child_process';
+
+/** Process-scoped macOS assertions; never changes global power-management preferences. */
+export class KeepAwake {
+  private child: ChildProcess | undefined;
+  constructor(private changed: () => void, private failed: (message: string) => void) {}
+  get active(): boolean { return !!this.child?.pid; }
+  update(enabled: boolean, running: boolean): void {
+    if (!enabled || !running || process.platform !== 'darwin') { this.stop(); return; }
+    if (this.child) return;
+    const child = spawn('/usr/bin/caffeinate', ['-is', '-w', String(process.pid)], { stdio: 'ignore' });
+    this.child = child;
+    child.once('spawn', this.changed);
+    child.once('error', () => {
+      if (this.child !== child) return;
+      this.child = undefined; this.changed();
+      this.failed('AirCodum could not enable Keep Mac awake. Check your Mac’s power settings.');
+    });
+    child.once('exit', () => { if (this.child === child) { this.child = undefined; this.changed(); } });
+  }
+  stop(): void {
+    const child = this.child; this.child = undefined;
+    child?.kill();
+    if (child) this.changed();
+  }
+}

--- a/extension/src/server.ts
+++ b/extension/src/server.ts
@@ -20,7 +20,23 @@ export async function startServer(address: string, token: string): Promise<void>
     server: httpServer, maxPayload: MAX_PAYLOAD, perMessageDeflate: false,
     verifyClient: ({ req }: { req: import('http').IncomingMessage }) => wss.clients.size < 4 && authorized(req, token),
   });
-  wss.on("connection", handleWebSocketConnection);
+  // The HTTP listener owns startup/runtime errors; consume ws’s forwarded copy.
+  wss.on("error", () => {});
+  const alive = new WeakMap<import('ws'), boolean>();
+  wss.on('connection', socket => {
+    alive.set(socket, true);
+    socket.on('pong', () => alive.set(socket, true));
+    handleWebSocketConnection(socket);
+  });
+  const heartbeat = setInterval(() => {
+    for (const socket of wss.clients) {
+      if (!alive.get(socket)) { socket.terminate(); continue; }
+      alive.set(socket, false);
+      socket.ping();
+    }
+  }, 30000);
+  heartbeat.unref();
+  wss.once('close', () => clearInterval(heartbeat));
   listener = httpServer;
   try {
     await new Promise<void>((resolve, reject) => {

--- a/extension/src/server.ts
+++ b/extension/src/server.ts
@@ -5,6 +5,7 @@ import { handleWebSocketConnection } from "./websockets";
 import { store } from "./state/store";
 import { setServerAddress, setServerRunning, setWebSocketServer } from "./state/actions";
 import { authorized, MAX_PAYLOAD, protectedBind } from "./security";
+import { connectionLog } from './connection-log';
 
 let listener: http.Server | undefined;
 let starting = false;
@@ -16,14 +17,29 @@ export async function startServer(address: string, token: string): Promise<void>
   if (!protectedBind(address)) throw new Error("Use localhost behind a TLS proxy, or bind to your Tailscale interface IP.");
   starting = true;
   const httpServer = http.createServer((_req, res) => { res.writeHead(404); res.end(); });
+  httpServer.on('clientError', (error: Error & { rawPacket?: Buffer }, socket) => {
+    const tls = error.rawPacket?.[0] === 0x16;
+    connectionLog(`Rejected transport from ${(socket as import('net').Socket).remoteAddress ?? 'unknown'}: ${tls ? 'TLS requested on plain WebSocket port; use Tailscale / localhost (ws)' : 'invalid HTTP handshake'}`);
+    socket.destroy();
+  });
   const wss = new WebSocketServer({
     server: httpServer, maxPayload: MAX_PAYLOAD, perMessageDeflate: false,
-    verifyClient: ({ req }: { req: import('http').IncomingMessage }) => wss.clients.size < 4 && authorized(req, token),
+    verifyClient: ({ req }: { req: import('http').IncomingMessage }) => {
+      const paired = authorized(req, token);
+      const accepted = wss.clients.size < 4 && paired;
+      const reason = wss.clients.size >= 4 ? 'client limit reached' :
+        req.headers.origin !== undefined && req.headers.origin !== 'aircodum://native' ? 'unsupported client origin' :
+        !req.headers.authorization ? 'missing pairing key' : 'incorrect pairing key';
+      connectionLog(`WebSocket ${accepted ? 'accepted' : `rejected: ${reason}`} from ${req.socket.remoteAddress ?? 'unknown'}`);
+      return accepted;
+    },
   });
   // The HTTP listener owns startup/runtime errors; consume ws’s forwarded copy.
   wss.on("error", () => {});
   const alive = new WeakMap<import('ws'), boolean>();
-  wss.on('connection', socket => {
+  wss.on('connection', (socket, request) => {
+    const peer = request.socket.remoteAddress ?? 'unknown';
+    socket.on('close', code => connectionLog(`WebSocket closed from ${peer}: code ${code}`));
     alive.set(socket, true);
     socket.on('pong', () => alive.set(socket, true));
     handleWebSocketConnection(socket);
@@ -47,6 +63,7 @@ export async function startServer(address: string, token: string): Promise<void>
         setServerAddress(address);
         setServerRunning(true);
         setWebSocketServer(wss);
+        connectionLog(`Listening on ${address}:${store.getState().server.port}`);
         resolve();
       });
     });

--- a/extension/src/server.ts
+++ b/extension/src/server.ts
@@ -3,7 +3,7 @@ import { WebSocketServer } from "ws";
 import * as vscode from "vscode";
 import { handleWebSocketConnection } from "./websockets";
 import { store } from "./state/store";
-import { setServerRunning, setWebSocketServer } from "./state/actions";
+import { setServerAddress, setServerRunning, setWebSocketServer } from "./state/actions";
 import { authorized, MAX_PAYLOAD, protectedBind } from "./security";
 
 let listener: http.Server | undefined;
@@ -28,6 +28,7 @@ export async function startServer(address: string, token: string): Promise<void>
       httpServer.listen(store.getState().server.port, address, () => {
         httpServer.removeListener("error", reject);
         httpServer.on("error", () => stopServer());
+        setServerAddress(address);
         setServerRunning(true);
         setWebSocketServer(wss);
         resolve();
@@ -41,11 +42,10 @@ export async function startServer(address: string, token: string): Promise<void>
 }
 
 export function stopServer(): void {
-  const { websocket, webview } = store.getState();
+  const { websocket } = store.getState();
   for (const client of websocket.wss?.clients ?? []) client.terminate();
   websocket.wss?.close();
   listener?.close(); listener = undefined;
   setWebSocketServer(null);
   setServerRunning(false);
-  webview.panel?.dispose();
 }

--- a/extension/src/websockets.ts
+++ b/extension/src/websockets.ts
@@ -351,6 +351,7 @@ class VSCodeVNCConnection {
         }
         const data = JSON.parse(text);
         switch (data.type) {
+          case 'ping': this.ws.send(JSON.stringify({ type: 'pong' })); break;
           case 'vnc_start': this.subscribeToFrameUpdates(); break;
           case 'vnc_stop': this.dispose(); break;
           case 'mouse-event': case 'vnc_mouse_event':
@@ -487,7 +488,7 @@ export function handleWebSocketConnection(ws: WebSocket) {
   console.log("New WebSocket connection");
   addWebSocketConnection(ws);
   ws.send(JSON.stringify({ type: 'server_capabilities', protocolVersion: 1,
-    features: { agents: [], pty: false, vnc: true, vncSharedPort: true,
+    features: { agents: [], pty: false, vnc: true, vncSharedPort: true, heartbeat: true,
       vncStreamControl: true, vncTextInput: true } }));
 
   // Create a connection instance for this socket

--- a/extension/src/webview-content.ts
+++ b/extension/src/webview-content.ts
@@ -1,0 +1,255 @@
+import { randomBytes } from 'crypto';
+
+export function getWebviewContent(): string {
+  const nonce = randomBytes(24).toString('hex');
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src data:; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AirCodum</title>
+  <style>
+    :root { color-scheme: light dark; }
+    * { box-sizing: border-box; }
+    [hidden] { display: none !important; }
+    body { margin: 0; padding: 28px 24px; font: 13px/1.5 var(--vscode-font-family, system-ui, sans-serif); color: var(--vscode-foreground, #d4d4d4); background: var(--vscode-editor-background, #1e1e1e); }
+    main { max-width: 600px; margin: auto; }
+    h1, h2, h3, p { margin: 0; }
+    h1 { font-size: 20px; font-weight: 650; letter-spacing: -.5px; }
+    h2 { font-size: 19px; font-weight: 600; letter-spacing: -.3px; }
+    h3 { font-size: 14px; font-weight: 600; }
+    button, input { font: inherit; }
+    button { cursor: pointer; border: 1px solid transparent; border-radius: 5px; padding: 8px 13px; line-height: 1.4; }
+    button:disabled { opacity: .5; cursor: default; }
+    button:focus-visible, input:focus-visible, summary:focus-visible { outline: 2px solid var(--vscode-focusBorder, #75beff); outline-offset: 3px; }
+    .primary { background: var(--vscode-button-background, #0078d4); color: var(--vscode-button-foreground, white); font-weight: 600; }
+    .primary:hover:not(:disabled) { background: var(--vscode-button-hoverBackground, #026ec1); }
+    .secondary { background: var(--vscode-button-secondaryBackground, #313131); color: var(--vscode-button-secondaryForeground, #eee); }
+    .secondary:hover:not(:disabled) { background: var(--vscode-button-secondaryHoverBackground, #454545); }
+    .quiet { color: var(--vscode-textLink-foreground, #75beff); background: transparent; padding: 4px 0; }
+    .quiet:hover { text-decoration: underline; }
+    .muted { color: var(--vscode-descriptionForeground, #aaa); }
+    .brand { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 24px; }
+    .brand p { font-size: 12px; margin-top: 2px; }
+    .status { display: inline-flex; align-items: center; gap: 7px; font-size: 12px; white-space: nowrap; }
+    .status::before { content: ''; width: 7px; height: 7px; border-radius: 50%; background: var(--vscode-descriptionForeground, #aaa); }
+    .status[data-state="ready"]::before { background: var(--vscode-charts-blue, #75beff); }
+    .status[data-state="connected"]::before { background: var(--vscode-testing-iconPassed, #73c991); }
+    .tabs { display: flex; gap: 22px; border-bottom: 1px solid var(--vscode-panel-border, #363636); margin-bottom: 24px; }
+    .tabs button { background: transparent; color: var(--vscode-descriptionForeground, #aaa); border-radius: 0; padding: 10px 0; border-bottom: 2px solid transparent; }
+    .tabs button[aria-selected="true"] { color: var(--vscode-foreground, #eee); border-bottom-color: var(--vscode-focusBorder, #75beff); }
+    .card { border: 1px solid var(--vscode-panel-border, #363636); border-radius: 10px; padding: 22px; }
+    .intro { margin: 6px 0 20px; }
+    .address { display: flex; justify-content: space-between; gap: 12px; align-items: baseline; margin: 0 0 22px; padding: 10px 12px; background: var(--vscode-textCodeBlock-background, #252526); border-radius: 5px; font-size: 12px; }
+    code { font-family: var(--vscode-editor-font-family, monospace); overflow-wrap: anywhere; text-align: right; }
+    .methods { display: flex; padding: 3px; gap: 3px; border-radius: 6px; background: var(--vscode-textCodeBlock-background, #252526); margin-bottom: 20px; }
+    .methods button { flex: 1; background: transparent; color: var(--vscode-descriptionForeground, #aaa); }
+    .methods button[aria-selected="true"] { background: var(--vscode-button-secondaryBackground, #393939); color: var(--vscode-button-secondaryForeground, #fff); border-color: var(--vscode-focusBorder, #75beff); }
+    .pairing { text-align: center; }
+    .pairing p { max-width: 360px; margin: 0 auto 16px; }
+    #pairingQr { display: block; width: min(240px, 100%); height: auto; margin: 0 auto 16px; border-radius: 8px; background: white; }
+    .caption { font-size: 12px; margin-top: 12px !important; }
+    dl { margin: 0 0 18px; }
+    .detail { display: grid; grid-template-columns: 90px minmax(0, 1fr); gap: 12px; padding: 8px 0; }
+    dt { color: var(--vscode-descriptionForeground, #aaa); }
+    dd { margin: 0; overflow-wrap: anywhere; font-weight: 500; }
+    .manual-help { margin-bottom: 16px; }
+    .settings { margin-top: 16px; border: 1px solid var(--vscode-panel-border, #363636); border-radius: 8px; }
+    summary { cursor: pointer; padding: 14px 16px; font-weight: 500; }
+    summary::marker { color: var(--vscode-descriptionForeground, #aaa); }
+    .settings-body { padding: 0 16px 16px; }
+    .setting-row { display: flex; justify-content: space-between; align-items: center; gap: 16px; padding: 13px 0; border-top: 1px solid var(--vscode-panel-border, #363636); }
+    .setting-row p { font-size: 12px; margin-top: 3px; }
+    .setting-row button { flex-shrink: 0; }
+    .power { padding: 14px 0; border-top: 1px solid var(--vscode-panel-border, #363636); }
+    .power label { display: flex; align-items: center; gap: 8px; cursor: pointer; }
+    input[type="checkbox"] { margin: 0; accent-color: var(--vscode-focusBorder, #75beff); width: 16px; height: 16px; }
+    .power p { margin: 7px 0 0 24px; font-size: 12px; }
+    .tools { border-top: 1px solid var(--vscode-panel-border, #363636); padding-top: 12px; }
+    .empty { padding: 30px 16px; text-align: center; }
+    .empty p { margin-top: 8px; }
+    .content { white-space: pre-wrap; overflow-wrap: anywhere; overflow: auto; max-height: 420px; padding: 14px; margin-top: 12px; background: var(--vscode-textCodeBlock-background, #252526); border-radius: 5px; }
+    #image { display: block; max-width: 100%; height: auto; margin-top: 14px; }
+    .received + .received { margin-top: 16px; }
+    .actions { display: flex; flex-wrap: wrap; gap: 16px; margin-top: 12px; }
+    .form-row { display: flex; align-items: stretch; gap: 8px; margin-top: 8px; }
+    input[type="text"], input[type="password"] { min-width: 0; width: 100%; padding: 9px 10px; border: 1px solid var(--vscode-input-border, #565656); border-radius: 5px; background: var(--vscode-input-background, #3c3c3c); color: var(--vscode-input-foreground, #eee); }
+    .form-row button { flex-shrink: 0; }
+    .api-settings { padding-bottom: 18px; margin-bottom: 18px; border-bottom: 1px solid var(--vscode-panel-border, #363636); }
+    #apiKeyForm { margin-top: 12px; }
+    #apiKeyStatus { margin-top: 4px; font-size: 12px; }
+    .error { display: flex; align-items: start; gap: 12px; padding: 12px; margin-bottom: 16px; border: 1px solid var(--vscode-inputValidation-errorBorder, #be6262); background: var(--vscode-inputValidation-errorBackground, #402626); border-radius: 6px; }
+    .error span { flex: 1; overflow-wrap: anywhere; }
+    .error button { color: inherit; background: none; padding: 0 4px; }
+    @media (max-width: 400px) { body { padding: 18px 12px; } .card { padding: 16px; } .brand { align-items: start; } .brand p { max-width: 160px; } .address { flex-direction: column; gap: 3px; } .form-row { flex-wrap: wrap; } .form-row button { width: 100%; } }
+    @media (forced-colors: active) { .methods button[aria-selected="true"] { border-color: Highlight; } .status::before { background: CanvasText; } }
+  </style>
+</head>
+<body>
+<main>
+  <header class="brand"><div><h1>AirCodum</h1><p class="muted">Your phone, connected to VS Code.</p></div><span id="serverState" class="status" role="status">Loading…</span></header>
+  <nav class="tabs" role="tablist" aria-label="AirCodum tools">
+    <button id="connectionTab" role="tab" aria-selected="true" aria-controls="connectionPanel" data-tab="connectionPanel">Connection</button>
+    <button id="workspaceTab" role="tab" aria-selected="false" aria-controls="workspacePanel" tabindex="-1" data-tab="workspacePanel">Files &amp; AI<span id="receivedBadge" hidden> · New</span></button>
+  </nav>
+  <div id="errorContainer" class="error" role="alert" hidden><span id="errorText"></span><button data-action="dismissError" aria-label="Dismiss error">×</button></div>
+  <section id="connectionPanel" role="tabpanel" aria-labelledby="connectionTab">
+    <div class="card">
+      <h2 id="connectionTitle">Connect your phone</h2>
+      <p id="connectionHint" class="intro muted">Loading your connection settings…</p>
+      <div class="address"><span id="addressKind" class="muted">Server address</span><code id="serverAddress">—</code></div>
+      <div class="methods" role="tablist" aria-label="Pairing method">
+        <button id="qrTab" role="tab" aria-selected="true" aria-controls="qrPanel" data-tab="qrPanel">QR code</button>
+        <button id="manualTab" role="tab" aria-selected="false" aria-controls="manualPanel" tabindex="-1" data-tab="manualPanel">Enter manually</button>
+      </div>
+      <div id="qrPanel" class="pairing" role="tabpanel" aria-labelledby="qrTab">
+        <div id="pairingQrContainer" hidden><img id="pairingQr" alt="Scan this pairing code with AirCodum on your phone"></div>
+        <p id="qrHint" class="muted">Connect Tailscale on your computer and phone.</p>
+        <button id="pairingAction" class="primary" data-action="pair" disabled>Show QR code</button>
+        <p class="caption muted">On your phone: AirCodum → Scan QR to connect.<br>Requires mobile version 2.4.1 or later.</p>
+      </div>
+      <div id="manualPanel" role="tabpanel" aria-labelledby="manualTab" hidden>
+        <p class="manual-help muted">Enter these details in AirCodum on your phone, then paste the pairing key.</p>
+        <dl><div class="detail"><dt>Host</dt><dd id="ipAddress">—</dd></div><div class="detail"><dt>Port</dt><dd id="serverPort">—</dd></div><div class="detail"><dt>Method</dt><dd id="transportLabel">Tailscale</dd></div></dl>
+        <button class="primary" id="copyPairingKey" data-action="copyPairingToken">Copy pairing key</button>
+        <p id="manualHint" class="caption muted"></p>
+      </div>
+    </div>
+    <details class="settings" id="serverSettings">
+      <summary>Server settings &amp; troubleshooting</summary>
+      <div class="settings-body">
+        <div class="setting-row"><div><h3>Connection address</h3><p class="muted">Choose Tailscale or a local TLS proxy.</p></div><button class="secondary" data-action="configureConnection">Change</button></div>
+        <div class="setting-row"><div><h3>Server</h3><p class="muted" id="serverControlHint">Loading…</p></div><button id="serverControl" class="secondary" data-action="toggleServer" disabled>Start server</button></div>
+        <div id="powerSettings" class="power" hidden>
+          <label><input id="keepAwake" type="checkbox">Keep Mac awake while the server runs</label>
+          <p id="powerStatus" class="muted" role="status"></p>
+          <p class="muted">Prevents idle sleep. Closing the lid can still put your Mac to sleep. For lid-closed use, connect power, an external display, and a keyboard and mouse.</p>
+        </div>
+        <div class="tools"><button class="quiet" data-action="showConnectionLog">Open connection log</button><p class="caption muted">See why a connection failed. Pairing keys are never logged.</p></div>
+      </div>
+    </details>
+  </section>
+  <section id="workspacePanel" role="tabpanel" aria-labelledby="workspaceTab" hidden>
+    <div id="waitingMessage" class="card empty"><h2>Ready to receive</h2><p class="muted">Send a file, image, or voice note from your phone.<br>It will appear here.</p></div>
+    <section id="fileContainer" class="card received" hidden><h2>Received file</h2><div id="fileContent" class="content"></div><img id="image" alt="Received image" hidden></section>
+    <section id="transcriptionContainer" class="card received" hidden><h2>Transcription</h2><pre id="transcription" class="content"></pre><div class="actions"><button class="quiet" data-action="copyToClipboard" data-target="transcription">Copy text</button><button class="quiet" data-action="addToCurrentFile" data-target="transcription">Insert into editor</button></div></section>
+    <details id="chatContainer" class="settings"><summary>AI assistant <span class="muted">· Optional</span></summary><div class="settings-body">
+      <div class="api-settings"><p class="muted">Ask about received files and code using your OpenAI API key. Phone pairing does not need an API key.</p><p id="apiKeyStatus" class="muted" role="status">No API key saved.</p><button class="quiet" data-action="editApiKey" id="editApiKey">Set up AI</button>
+        <form id="apiKeyForm" hidden><label for="apiKeyInput">OpenAI API key</label><div class="form-row"><input type="password" id="apiKeyInput" placeholder="Paste your API key" autocomplete="off" required maxlength="1024"><button class="secondary" type="submit">Save key</button></div></form>
+      </div>
+      <form id="chatForm"><label for="chatInput">Ask about your file or code</label><div class="form-row"><input type="text" id="chatInput" placeholder="What would you like to know?" maxlength="4096" required><button id="sendChat" class="primary" type="submit">Send</button></div></form>
+      <div id="chatResponse" class="content" hidden></div><div id="chatActions" class="actions" hidden><button class="quiet" data-action="copyToClipboard" data-target="chatResponse">Copy response</button><button class="quiet" data-action="addToCurrentFile" data-target="chatResponse">Insert into editor</button></div>
+    </div></details>
+  </section>
+</main>
+<script nonce="${nonce}">
+  const vscode = acquireVsCodeApi();
+  const el = id => document.getElementById(id);
+  let connection, connectionIdentity, qrRequested = false, apiKeySaved = false;
+  const post = command => vscode.postMessage({ command });
+  const hideQr = () => { qrRequested = false; el('pairingQrContainer').hidden = true; el('pairingQr').removeAttribute('src'); };
+  const isLocal = host => host === 'localhost' || host === '::1' || host.startsWith('127.');
+  function renderConnection() {
+    if (!connection) return;
+    const c = connection, local = isLocal(c.host), count = c.running ? c.clients : 0;
+    el('serverState').textContent = count ? 'Connected' : c.running ? 'Server running' : 'Server stopped';
+    el('serverState').dataset.state = count ? 'connected' : c.running ? 'ready' : 'stopped';
+    el('connectionTitle').textContent = count ? "You're connected" : 'Connect your phone';
+    el('connectionHint').textContent = count ? count + (count === 1 ? ' active connection. Your phone is ready to use.' : ' active connections. Your devices are ready to use.') : 'Use QR pairing or enter the connection details yourself.';
+    el('serverAddress').textContent = (c.host.includes(':') ? '[' + c.host + ']' : c.host) + ':' + c.port;
+    el('addressKind').textContent = local ? 'Local server' : 'Tailscale address';
+    el('ipAddress').textContent = c.host;
+    el('serverPort').textContent = String(c.port);
+    el('transportLabel').textContent = local ? 'Localhost / your TLS proxy' : 'Tailscale';
+    el('manualHint').textContent = !c.running ? 'The server is stopped. Start it in Server settings below.' : local ? 'This address only works on this computer. For phone access, change to Tailscale below or use your configured TLS proxy address.' : 'Choose Tailscale on your phone (called Tailscale / localhost (ws) in older versions). Connect both devices to the same Tailscale account.';
+    el('qrHint').textContent = !c.running ? 'Start the server, then pair your phone.' : local ? 'Choose your Tailscale address so your phone can reach this computer.' : qrRequested ? 'Open AirCodum on your phone and scan this code.' : 'Connect both devices to the same Tailscale account, then scan to pair.';
+    const action = el('pairingAction');
+    action.disabled = qrRequested && el('pairingQrContainer').hidden;
+    action.textContent = !c.running ? 'Start server' : local ? 'Choose Tailscale' : qrRequested ? (el('pairingQrContainer').hidden ? 'Creating QR code…' : 'Hide QR code') : count ? 'Pair another phone' : 'Show QR code';
+    el('serverControl').textContent = c.running ? 'Stop server' : 'Start server';
+    el('serverControl').disabled = false;
+    el('serverControlHint').textContent = c.running ? 'Stopping disconnects your phone.' : 'Start to accept connections.';
+    el('powerSettings').hidden = !c.mac;
+  }
+  function chooseTab(button, focus = false) {
+    const group = button.parentElement;
+    group.querySelectorAll('[role="tab"]').forEach(tab => {
+      const selected = tab === button;
+      tab.setAttribute('aria-selected', String(selected)); tab.tabIndex = selected ? 0 : -1;
+      el(tab.dataset.tab).hidden = !selected;
+    });
+    if (button.id === 'manualTab' || button.id === 'workspaceTab') { hideQr(); renderConnection(); }
+    if (button.id === 'workspaceTab') el('receivedBadge').hidden = true;
+    if (focus) button.focus();
+  }
+  document.querySelectorAll('[role="tablist"]').forEach(group => {
+    group.querySelectorAll('[role="tab"]').forEach(tab => tab.addEventListener('click', () => chooseTab(tab)));
+    group.addEventListener('keydown', event => {
+      const tabs = [...group.querySelectorAll('[role="tab"]')], index = tabs.indexOf(document.activeElement);
+      if (index < 0 || !['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return;
+      event.preventDefault();
+      chooseTab(tabs[event.key === 'Home' ? 0 : event.key === 'End' ? tabs.length - 1 : (index + (event.key === 'ArrowRight' ? 1 : -1) + tabs.length) % tabs.length], true);
+    });
+  });
+  function showError(message) { el('errorText').textContent = message; el('errorContainer').hidden = false; }
+  const actions = {
+    pair: () => {
+      if (!connection) return;
+      if (!connection.running) return post('startServer');
+      if (isLocal(connection.host)) return post('configureConnection');
+      if (qrRequested) hideQr(); else { qrRequested = true; post('showPairingQr'); }
+      renderConnection();
+    },
+    toggleServer: () => post(connection?.running ? 'stopServer' : 'startServer'),
+    configureConnection: () => post('configureConnection'),
+    copyPairingToken: () => post('copyPairingToken'),
+    showConnectionLog: () => post('showConnectionLog'),
+    dismissError: () => { el('errorContainer').hidden = true; },
+    editApiKey: () => { el('apiKeyForm').hidden = !el('apiKeyForm').hidden; if (!el('apiKeyForm').hidden) el('apiKeyInput').focus(); },
+    copyToClipboard: target => navigator.clipboard.writeText(el(target).textContent).then(() => vscode.postMessage({ command: 'showInfo', message: 'Copied to clipboard.' })).catch(() => showError('Could not copy to the clipboard.')),
+    addToCurrentFile: target => vscode.postMessage({ command: 'addToCurrentFile', text: el(target).textContent }),
+  };
+  document.querySelectorAll('[data-action]').forEach(button => button.addEventListener('click', () => actions[button.dataset.action](button.dataset.target)));
+  el('keepAwake').addEventListener('change', () => { el('keepAwake').disabled = true; post('toggleKeepAwake'); });
+  el('apiKeyForm').addEventListener('submit', event => { event.preventDefault(); const key = el('apiKeyInput').value.trim(); if (!key) return; vscode.postMessage({ command: 'saveApiKey', key }); el('apiKeyInput').value = ''; });
+  el('chatForm').addEventListener('submit', event => {
+    event.preventDefault();
+    if (!apiKeySaved) { el('apiKeyForm').hidden = false; el('apiKeyInput').focus(); return; }
+    const prompt = el('chatInput').value.trim(); if (!prompt) return;
+    vscode.postMessage({ command: 'chat', prompt }); el('chatInput').value = '';
+  });
+  function received() { el('waitingMessage').hidden = true; el('receivedBadge').hidden = !el('workspacePanel').hidden; }
+  window.addEventListener('message', event => {
+    const m = event.data;
+    switch (m.type) {
+      case 'connection': {
+        const identity = JSON.stringify([m.host, m.port, m.running]);
+        if (identity !== connectionIdentity) hideQr();
+        connectionIdentity = identity; connection = m; renderConnection(); break;
+      }
+      case 'pairingQr':
+        if (!qrRequested || !connection?.running || el('qrPanel').hidden || el('connectionPanel').hidden) break;
+        el('pairingQr').src = m.dataUrl; el('pairingQrContainer').hidden = false; el('errorContainer').hidden = true; renderConnection(); break;
+      case 'power':
+        el('keepAwake').checked = m.enabled; el('keepAwake').disabled = false;
+        el('powerStatus').textContent = m.active ? 'On — idle sleep is prevented.' : m.enabled ? 'On — will activate when the server starts.' : 'Off — your normal sleep settings apply.'; break;
+      case 'apiKeyStatus':
+        apiKeySaved = m.saved; el('apiKeyStatus').textContent = m.saved ? 'API key saved securely.' : 'No API key saved.';
+        el('editApiKey').textContent = m.saved ? 'Change API key' : 'Set up AI'; if (m.saved) el('apiKeyForm').hidden = true; break;
+      case 'pairingKeyCopied':
+        el('copyPairingKey').textContent = 'Pairing key copied'; setTimeout(() => { el('copyPairingKey').textContent = 'Copy pairing key'; }, 3500); break;
+      case 'file':
+        if (m.fileType === 'image') { el('image').src = 'data:image/png;base64,' + m.content; el('image').hidden = false; el('fileContent').hidden = true; }
+        else { el('fileContent').textContent = m.content; el('fileContent').hidden = false; el('image').hidden = true; el('image').removeAttribute('src'); el('transcriptionContainer').hidden = true; }
+        el('fileContainer').hidden = false; received(); break;
+      case 'transcription': el('transcription').textContent = m.text; el('transcriptionContainer').hidden = false; received(); break;
+      case 'chatResponse': el('chatResponse').textContent = m.response; el('chatResponse').hidden = false; el('chatActions').hidden = false; break;
+      case 'error': hideQr(); renderConnection(); el('keepAwake').disabled = false; showError(m.message); break;
+    }
+  });
+  post('connection');
+</script>
+</body>
+</html>`;
+}

--- a/extension/src/webview.ts
+++ b/extension/src/webview.ts
@@ -1,11 +1,12 @@
 import * as vscode from "vscode";
-import { getApiKey, saveApiKey } from "./ai/utils";
+import { getApiKey, getPairingToken, saveApiKey } from "./ai/utils";
 import { setWebviewPanel } from "./state/actions";
 import { handleChat } from "./ai/api";
 
 import { randomBytes } from "crypto";
 import { store } from "./state/store";
-import { connectionDetails } from "./connection";
+import * as QRCode from "qrcode";
+import { connectionDetails, pairingCode } from "./connection";
 
 function getWebviewContent(): string {
   const nonce = randomBytes(24).toString("hex");
@@ -135,10 +136,22 @@ function getWebviewContent(): string {
         <p>On your phone, select <strong>Tailscale / localhost (ws)</strong> for a direct connection.
         Connect Tailscale on both devices using the same account.</p>
         <div class="connection-actions">
+            <button data-action="showPairingQr">Show pairing QR</button>
             <button data-action="configureConnection">Choose connection</button>
             <button data-action="copyPairingToken">Copy pairing key</button>
             <button data-action="startServer">Start server</button>
             <button data-action="stopServer">Stop server</button>
+        </div>
+        <div id="pairingQrContainer" style="display: none; margin-top: 16px;">
+            <img id="pairingQr" alt="AirCodum pairing QR code" style="width: min(320px, 100%); height: auto; background: white; border-radius: 8px;">
+            <p>In AirCodum on your phone, tap <strong>Scan QR to connect</strong>. Requires AirCodum 2.4.1 or later.</p>
+            <button data-action="hidePairingQr">Hide QR code</button>
+        </div>
+        <div id="powerSettings" style="display: none; margin-top: 20px;">
+            <h2>Stay connected</h2>
+            <button data-action="toggleKeepAwake">Toggle Keep Mac awake</button>
+            <p id="powerStatus" aria-live="polite"></p>
+            <p>Keep Mac awake prevents idle sleep while the server runs. Closing the lid can still put macOS to sleep. For supported lid-closed operation, connect power, an external display, and a keyboard and mouse. AirCodum on your phone reconnects when the Mac is reachable again.</p>
         </div>
         <p>The pairing key is required in the phone’s connection settings. Copy it here and paste it on your phone.</p>
         <div>
@@ -178,7 +191,11 @@ function getWebviewContent(): string {
   
     <script nonce="${nonce}">
         const vscode = acquireVsCodeApi();
+        let connectionIdentity;
         const actions = { saveApiKey, copyToClipboard, addToCurrentFile, chat,
+          showPairingQr: () => vscode.postMessage({command: 'showPairingQr'}),
+          hidePairingQr: () => { document.getElementById('pairingQrContainer').style.display = 'none'; document.getElementById('pairingQr').removeAttribute('src'); },
+          toggleKeepAwake: () => vscode.postMessage({command: 'toggleKeepAwake'}),
           configureConnection: () => vscode.postMessage({command: 'configureConnection'}),
           copyPairingToken: () => vscode.postMessage({command: 'copyPairingToken'}),
           startServer: () => vscode.postMessage({command: 'startServer'}),
@@ -245,7 +262,19 @@ function getWebviewContent(): string {
                 case 'chatResponse':
                     handleChatResponseMessage(message);
                     break;
+                case 'power':
+                    document.getElementById('powerStatus').textContent = message.active ? 'Keep Mac awake is active while the server runs.' : 'Keep Mac awake is off or the server is stopped.';
+                    break;
+                case 'pairingQr':
+                    document.getElementById('pairingQr').src = message.dataUrl;
+                    document.getElementById('pairingQrContainer').style.display = 'block';
+                    document.getElementById('errorContainer').style.display = 'none';
+                    break;
                 case 'connection':
+                    const identity = JSON.stringify([message.host, message.port, message.running]);
+                    if (identity !== connectionIdentity) actions.hidePairingQr();
+                    connectionIdentity = identity;
+                    document.getElementById('powerSettings').style.display = message.mac ? 'block' : 'none';
                     document.getElementById('ipAddress').textContent = message.host;
                     document.getElementById('serverPort').textContent = String(message.port);
                     document.getElementById('serverState').textContent = message.running ? 'Running' : 'Stopped';
@@ -312,7 +341,7 @@ export function createWebviewPanel(
   const sendConnection = () => {
     const server = store.getState().server;
     const configured = vscode.workspace.getConfiguration("aircodum").get<string>("bindAddress", "127.0.0.1");
-    panel.webview.postMessage({ type: "connection", ...connectionDetails(server, configured) });
+    panel.webview.postMessage({ type: "connection", mac: process.platform === "darwin", ...connectionDetails(server, configured) });
   };
   const unsubscribe = store.subscribe(sendConnection);
 
@@ -333,9 +362,27 @@ export function createWebviewPanel(
         case "addToCurrentFile":
           addToCurrentFile(message.text);
           break;
+        case "toggleKeepAwake":
+          await vscode.commands.executeCommand('extension.toggleAirCodumKeepAwake');
+          break;
         case "connection":
           sendConnection();
+          await vscode.commands.executeCommand('extension.aircodumPowerStatus');
           break;
+        case "showPairingQr": {
+          try {
+            const server = store.getState().server;
+            const payload = pairingCode(server, await getPairingToken());
+            const dataUrl = await QRCode.toDataURL(payload, { width: 640, margin: 4, errorCorrectionLevel: 'M' });
+            const current = store.getState().server;
+            if (current.isRunning && current.address === server.address && current.port === server.port) {
+              panel.webview.postMessage({ type: "pairingQr", dataUrl });
+            }
+          } catch (error) {
+            panel.webview.postMessage({ type: "error", message: error instanceof Error ? error.message : "Unable to create pairing QR code." });
+          }
+          break;
+        }
         case "configureConnection":
           await vscode.commands.executeCommand("extension.configureAirCodumConnection");
           break;

--- a/extension/src/webview.ts
+++ b/extension/src/webview.ts
@@ -3,323 +3,11 @@ import { getApiKey, getPairingToken, saveApiKey } from "./ai/utils";
 import { setWebviewPanel } from "./state/actions";
 import { handleChat } from "./ai/api";
 
-import { randomBytes } from "crypto";
+import { getWebviewContent } from "./webview-content";
+import { showConnectionLog } from "./connection-log";
 import { store } from "./state/store";
 import * as QRCode from "qrcode";
 import { connectionDetails, pairingCode } from "./connection";
-
-function getWebviewContent(): string {
-  const nonce = randomBytes(24).toString("hex");
-  return `<!DOCTYPE html>
-  <html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src data:; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AirCodum</title>
-    <style>
-        body {
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            line-height: 1.6;
-            margin: 0;
-            padding: 20px;
-            background-color: #1e1e1e;
-            color: #d4d4d4;
-        }
-        .container {
-            max-width: 800px;
-            margin: 0 auto;
-            background-color: #252526;
-            padding: 30px;
-            border-radius: 8px;
-            box-shadow: 0 0 20px rgba(0,0,0,0.3);
-        }
-        h1, h2 {
-            color: #569cd6;
-        }
-        input[type="password"], input[type="text"] {
-            width: 70%;
-            padding: 10px;
-            margin-right: 10px;
-            background-color: #3c3c3c;
-            color: #d4d4d4;
-            border: 1px solid #565656;
-            border-radius: 4px;
-        }
-        button {
-            padding: 10px 15px;
-            background-color: #0e639c;
-            color: #fff;
-            border: none;
-            border-radius: 4px;
-            cursor: pointer;
-            transition: background-color 0.3s ease;
-        }
-        .connection-actions { display: flex; flex-wrap: wrap; gap: 8px; }
-        button:disabled { opacity: 0.5; cursor: default; }
-        button:focus-visible { outline: 2px solid var(--vscode-focusBorder, #569cd6); outline-offset: 2px; }
-        .status-value { overflow-wrap: anywhere; }
-        button:hover {
-            background-color: #1177bb;
-        }
-        #fileContent, #transcription, #chatResponse {
-            background-color: #1e1e1e;
-            border: 1px solid #3c3c3c;
-            border-radius: 4px;
-            padding: 15px;
-            margin-top: 20px;
-            white-space: pre-wrap;
-            overflow-x: auto;
-        }
-        .error {
-            color: #f48771;
-            background-color: #5a1d1d;
-            border: 1px solid #8a2c2c;
-            border-radius: 4px;
-            padding: 10px;
-            margin-top: 20px;
-        }
-        .logo {
-            font-size: 2.5em;
-            font-weight: bold;
-            color: #569cd6;
-            margin-bottom: 10px;
-        }
-        .tagline {
-            font-style: italic;
-            color: #9cdcfe;
-            margin-bottom: 20px;
-        }
-        #image {
-            max-width: 100%;
-            height: auto;
-            margin-top: 20px;
-            border: 1px solid #3c3c3c;
-            border-radius: 4px;
-        }
-        .status {
-            padding: 10px;
-            background-color: #3c3c3c;
-            border-radius: 4px;
-            margin-bottom: 20px;
-        }
-        .status-item {
-            display: flex;
-            justify-content: space-between;
-            margin-bottom: 5px;
-        }
-        .status-value {
-            font-weight: bold;
-            color: #9cdcfe;
-        }
-    </style>
-  </head>
-  <body>
-    <div class="container">
-        <div class="logo">AirCodum</div>
-        <div class="tagline">Airdrop for your Code</div>
-        
-        <h2>Connect your phone</h2>
-        <div class="status" aria-live="polite">
-            <div class="status-item"><span>Server:</span><span id="serverState" class="status-value"></span></div>
-            <div class="status-item">
-                <span>Host:</span>
-                <span id="ipAddress" class="status-value"></span>
-            </div>
-            <div class="status-item">
-                <span>Port:</span>
-                <span id="serverPort" class="status-value"></span>
-            </div>
-        </div>
-        
-        <p id="connectionHint"></p>
-        <p>On your phone, select <strong>Tailscale / localhost (ws)</strong> for a direct connection.
-        Connect Tailscale on both devices using the same account.</p>
-        <div class="connection-actions">
-            <button data-action="showPairingQr">Show pairing QR</button>
-            <button data-action="configureConnection">Choose connection</button>
-            <button data-action="copyPairingToken">Copy pairing key</button>
-            <button data-action="startServer">Start server</button>
-            <button data-action="stopServer">Stop server</button>
-        </div>
-        <div id="pairingQrContainer" style="display: none; margin-top: 16px;">
-            <img id="pairingQr" alt="AirCodum pairing QR code" style="width: min(320px, 100%); height: auto; background: white; border-radius: 8px;">
-            <p>In AirCodum on your phone, tap <strong>Scan QR to connect</strong>. Requires AirCodum 2.4.1 or later.</p>
-            <button data-action="hidePairingQr">Hide QR code</button>
-        </div>
-        <div id="powerSettings" style="display: none; margin-top: 20px;">
-            <h2>Stay connected</h2>
-            <button data-action="toggleKeepAwake">Toggle Keep Mac awake</button>
-            <p id="powerStatus" aria-live="polite"></p>
-            <p>Keep Mac awake prevents idle sleep while the server runs. Closing the lid can still put macOS to sleep. For supported lid-closed operation, connect power, an external display, and a keyboard and mouse. AirCodum on your phone reconnects when the Mac is reachable again.</p>
-        </div>
-        <p>The pairing key is required in the phone’s connection settings. Copy it here and paste it on your phone.</p>
-        <div>
-            <h2>OpenAI API Key</h2>
-            <input type="password" id="apiKeyInput" placeholder="Enter your OpenAI API key">
-            <button data-action="saveApiKey">Save Key</button>
-        </div>
-        
-        <div id="fileContainer" style="display: none;">
-            <h2>Received File</h2>
-            <div id="fileContent"></div>
-            <img id="image" style="display: none;" alt="Received image">
-        </div>
-        
-        <div id="transcriptionContainer" style="display: none;">
-            <h2>Transcription</h2>
-            <pre id="transcription"></pre>
-            <button data-action="copyToClipboard" data-target="transcription">Copy to Clipboard</button>
-            <button data-action="addToCurrentFile" data-target="transcription">Add to Current File</button>
-        </div>
-        
-        <div id="chatContainer">
-            <h2>Chat with AI</h2>
-            <input type="text" id="chatInput" placeholder="Ask about the file or code...">
-            <button data-action="chat">Send</button>
-            <div id="chatResponse" style="display: none;"></div>
-            <button data-action="copyToClipboard" data-target="chatResponse" style="display: none;">Copy to Clipboard</button>
-            <button data-action="addToCurrentFile" data-target="chatResponse" style="display: none;">Add to Current File</button>
-        </div>
-        
-        <div id="waitingMessage">
-            <p>Waiting for a file to be received...</p>
-        </div>
-        
-        <div id="errorContainer" class="error" style="display: none;"></div>
-    </div>
-  
-    <script nonce="${nonce}">
-        const vscode = acquireVsCodeApi();
-        let connectionIdentity;
-        const actions = { saveApiKey, copyToClipboard, addToCurrentFile, chat,
-          showPairingQr: () => vscode.postMessage({command: 'showPairingQr'}),
-          hidePairingQr: () => { document.getElementById('pairingQrContainer').style.display = 'none'; document.getElementById('pairingQr').removeAttribute('src'); },
-          toggleKeepAwake: () => vscode.postMessage({command: 'toggleKeepAwake'}),
-          configureConnection: () => vscode.postMessage({command: 'configureConnection'}),
-          copyPairingToken: () => vscode.postMessage({command: 'copyPairingToken'}),
-          startServer: () => vscode.postMessage({command: 'startServer'}),
-          stopServer: () => vscode.postMessage({command: 'stopServer'}),
-        };
-        document.querySelectorAll('[data-action]').forEach(button => {
-          button.addEventListener('click', () => actions[button.dataset.action](button.dataset.target));
-        });
-  
-        function saveApiKey() {
-            const apiKey = document.getElementById('apiKeyInput').value;
-            vscode.postMessage({
-                command: 'saveApiKey',
-                key: apiKey
-            });
-            document.getElementById('apiKeyInput').value = '';
-        }
-  
-        function copyToClipboard(elementId) {
-            const element = document.getElementById(elementId);
-            const text = element.textContent;
-            navigator.clipboard.writeText(text)
-                .then(() => vscode.postMessage({ command: 'showInfo', message: 'Content copied to clipboard!' }))
-                .catch(() => showError('Failed to copy content to clipboard.'));
-        }
-  
-        function addToCurrentFile(elementId) {
-            const element = document.getElementById(elementId);
-            const text = element.textContent;
-            vscode.postMessage({
-                command: 'addToCurrentFile',
-                text: text
-            });
-        }
-  
-        function chat() {
-            const chatInput = document.getElementById('chatInput');
-            const prompt = chatInput.value;
-            if (prompt.trim() === '') return;
-  
-            vscode.postMessage({
-                command: 'chat',
-                prompt: prompt
-            });
-  
-            chatInput.value = '';
-        }
-  
-        function showError(message) {
-            const errorContainer = document.getElementById('errorContainer');
-            errorContainer.textContent = message;
-            errorContainer.style.display = 'block';
-        }
-  
-        window.addEventListener('message', event => {
-            const message = event.data;
-            switch (message.type) {
-                case 'file':
-                    handleFileMessage(message);
-                    break;
-                case 'transcription':
-                    handleTranscriptionMessage(message);
-                    break;
-                case 'chatResponse':
-                    handleChatResponseMessage(message);
-                    break;
-                case 'power':
-                    document.getElementById('powerStatus').textContent = message.active ? 'Keep Mac awake is active while the server runs.' : 'Keep Mac awake is off or the server is stopped.';
-                    break;
-                case 'pairingQr':
-                    document.getElementById('pairingQr').src = message.dataUrl;
-                    document.getElementById('pairingQrContainer').style.display = 'block';
-                    document.getElementById('errorContainer').style.display = 'none';
-                    break;
-                case 'connection':
-                    const identity = JSON.stringify([message.host, message.port, message.running]);
-                    if (identity !== connectionIdentity) actions.hidePairingQr();
-                    connectionIdentity = identity;
-                    document.getElementById('powerSettings').style.display = message.mac ? 'block' : 'none';
-                    document.getElementById('ipAddress').textContent = message.host;
-                    document.getElementById('serverPort').textContent = String(message.port);
-                    document.getElementById('serverState').textContent = message.running ? 'Running' : 'Stopped';
-                    document.getElementById('connectionHint').textContent = message.hint;
-                    document.querySelector('[data-action="startServer"]').disabled = message.running;
-                    document.querySelector('[data-action="stopServer"]').disabled = !message.running;
-                    break;
-                case 'error':
-                    showError(message.message);
-                    break;
-            }
-        });
-  
-        function handleFileMessage(message) {
-            if (message.fileType === 'image') {
-                document.getElementById('image').src = 'data:image/png;base64,' + message.content;
-                document.getElementById('image').style.display = 'block';
-                document.getElementById('fileContent').style.display = 'none';
-            } else {
-                document.getElementById('transcription').textContent = "";
-                document.getElementById('transcriptionContainer').style.display = 'none';
-                document.getElementById('fileContent').textContent = message.content;
-                document.getElementById('fileContent').style.display = 'block';
-                document.getElementById('image').style.display = 'none';
-            }
-            document.getElementById('fileContainer').style.display = 'block';
-            document.getElementById('waitingMessage').style.display = 'none';
-        }
-  
-        function handleTranscriptionMessage(message) {
-            document.getElementById('transcription').textContent = message.text;
-            document.getElementById('transcriptionContainer').style.display = 'block';
-        }
-  
-        function handleChatResponseMessage(message) {
-            document.getElementById('chatResponse').textContent = message.response;
-            document.getElementById('chatResponse').style.display = 'block';
-            document.querySelectorAll('#chatContainer button').forEach(btn => btn.style.display = 'inline-block');
-        }
-  
-        vscode.postMessage({ command: 'connection' });
-    </script>
-  </body>
-  </html>`;
-}
 
 export function createWebviewPanel(
   context: vscode.ExtensionContext
@@ -331,7 +19,7 @@ export function createWebviewPanel(
     {
       enableScripts: true,
       localResourceRoots: [],
-      retainContextWhenHidden: true, // Add this option
+      retainContextWhenHidden: true,
     }
   );
 
@@ -341,14 +29,17 @@ export function createWebviewPanel(
   const sendConnection = () => {
     const server = store.getState().server;
     const configured = vscode.workspace.getConfiguration("aircodum").get<string>("bindAddress", "127.0.0.1");
-    panel.webview.postMessage({ type: "connection", mac: process.platform === "darwin", ...connectionDetails(server, configured) });
+    panel.webview.postMessage({ type: "connection", clients: store.getState().websocket.connections.filter(socket => socket.readyState === 1).length, mac: process.platform === "darwin", ...connectionDetails(server, configured) });
   };
   const unsubscribe = store.subscribe(sendConnection);
+  const configSubscription = vscode.workspace.onDidChangeConfiguration(event => {
+    if (event.affectsConfiguration("aircodum.bindAddress")) sendConnection();
+  });
 
-  // Add this event listener
   panel.onDidDispose(
     () => {
       unsubscribe();
+      configSubscription.dispose();
       setWebviewPanel(null);
     },
     null,
@@ -358,6 +49,7 @@ export function createWebviewPanel(
   panel.webview.onDidReceiveMessage(
     async (message) => {
       if (!message || typeof message.command !== "string") return;
+      try {
       switch (message.command) {
         case "addToCurrentFile":
           addToCurrentFile(message.text);
@@ -365,8 +57,12 @@ export function createWebviewPanel(
         case "toggleKeepAwake":
           await vscode.commands.executeCommand('extension.toggleAirCodumKeepAwake');
           break;
+        case "showConnectionLog":
+          showConnectionLog();
+          break;
         case "connection":
           sendConnection();
+          panel.webview.postMessage({ type: "apiKeyStatus", saved: Boolean(getApiKey()) });
           await vscode.commands.executeCommand('extension.aircodumPowerStatus');
           break;
         case "showPairingQr": {
@@ -388,6 +84,7 @@ export function createWebviewPanel(
           break;
         case "copyPairingToken":
           await vscode.commands.executeCommand("extension.copyAirCodumPairingToken");
+          panel.webview.postMessage({ type: "pairingKeyCopied" });
           break;
         case "startServer":
           await vscode.commands.executeCommand("extension.startAirCodumServer");
@@ -397,6 +94,7 @@ export function createWebviewPanel(
           break;
         case "saveApiKey":
           await saveApiKey(message.key);
+          panel.webview.postMessage({ type: "apiKeyStatus", saved: Boolean(getApiKey()) });
           break;
         case "chat":
           if (typeof message.prompt === "string" && message.prompt.length <= 4096) await handleChat(message.prompt, getApiKey());
@@ -404,6 +102,9 @@ export function createWebviewPanel(
         case "showInfo":
           vscode.window.showInformationMessage(message.message);
           break;
+      }
+      } catch (error) {
+        panel.webview.postMessage({ type: "error", message: error instanceof Error ? error.message : "Unable to complete this action." });
       }
     },
     undefined,

--- a/extension/src/webview.ts
+++ b/extension/src/webview.ts
@@ -4,6 +4,8 @@ import { setWebviewPanel } from "./state/actions";
 import { handleChat } from "./ai/api";
 
 import { randomBytes } from "crypto";
+import { store } from "./state/store";
+import { connectionDetails } from "./connection";
 
 function getWebviewContent(): string {
   const nonce = randomBytes(24).toString("hex");
@@ -52,6 +54,10 @@ function getWebviewContent(): string {
             cursor: pointer;
             transition: background-color 0.3s ease;
         }
+        .connection-actions { display: flex; flex-wrap: wrap; gap: 8px; }
+        button:disabled { opacity: 0.5; cursor: default; }
+        button:focus-visible { outline: 2px solid var(--vscode-focusBorder, #569cd6); outline-offset: 2px; }
+        .status-value { overflow-wrap: anywhere; }
         button:hover {
             background-color: #1177bb;
         }
@@ -112,17 +118,29 @@ function getWebviewContent(): string {
         <div class="logo">AirCodum</div>
         <div class="tagline">Airdrop for your Code</div>
         
-        <div class="status">
+        <h2>Connect your phone</h2>
+        <div class="status" aria-live="polite">
+            <div class="status-item"><span>Server:</span><span id="serverState" class="status-value"></span></div>
             <div class="status-item">
-                <span>IP Address:</span>
+                <span>Host:</span>
                 <span id="ipAddress" class="status-value"></span>
             </div>
             <div class="status-item">
                 <span>Port:</span>
-                <span class="status-value">11040</span>
+                <span id="serverPort" class="status-value"></span>
             </div>
         </div>
         
+        <p id="connectionHint"></p>
+        <p>On your phone, select <strong>Tailscale / localhost (ws)</strong> for a direct connection.
+        Connect Tailscale on both devices using the same account.</p>
+        <div class="connection-actions">
+            <button data-action="configureConnection">Choose connection</button>
+            <button data-action="copyPairingToken">Copy pairing key</button>
+            <button data-action="startServer">Start server</button>
+            <button data-action="stopServer">Stop server</button>
+        </div>
+        <p>The pairing key is required in the phone’s connection settings. Copy it here and paste it on your phone.</p>
         <div>
             <h2>OpenAI API Key</h2>
             <input type="password" id="apiKeyInput" placeholder="Enter your OpenAI API key">
@@ -160,7 +178,12 @@ function getWebviewContent(): string {
   
     <script nonce="${nonce}">
         const vscode = acquireVsCodeApi();
-        const actions = { saveApiKey, copyToClipboard, addToCurrentFile, chat };
+        const actions = { saveApiKey, copyToClipboard, addToCurrentFile, chat,
+          configureConnection: () => vscode.postMessage({command: 'configureConnection'}),
+          copyPairingToken: () => vscode.postMessage({command: 'copyPairingToken'}),
+          startServer: () => vscode.postMessage({command: 'startServer'}),
+          stopServer: () => vscode.postMessage({command: 'stopServer'}),
+        };
         document.querySelectorAll('[data-action]').forEach(button => {
           button.addEventListener('click', () => actions[button.dataset.action](button.dataset.target));
         });
@@ -222,8 +245,13 @@ function getWebviewContent(): string {
                 case 'chatResponse':
                     handleChatResponseMessage(message);
                     break;
-                case 'ipAddress':
-                    document.getElementById('ipAddress').textContent = message.ipAddress;
+                case 'connection':
+                    document.getElementById('ipAddress').textContent = message.host;
+                    document.getElementById('serverPort').textContent = String(message.port);
+                    document.getElementById('serverState').textContent = message.running ? 'Running' : 'Stopped';
+                    document.getElementById('connectionHint').textContent = message.hint;
+                    document.querySelector('[data-action="startServer"]').disabled = message.running;
+                    document.querySelector('[data-action="stopServer"]').disabled = !message.running;
                     break;
                 case 'error':
                     showError(message.message);
@@ -258,16 +286,14 @@ function getWebviewContent(): string {
             document.querySelectorAll('#chatContainer button').forEach(btn => btn.style.display = 'inline-block');
         }
   
-        // Request the API key when the webview loads
-        vscode.postMessage({ command: 'ipAddress' });
+        vscode.postMessage({ command: 'connection' });
     </script>
   </body>
   </html>`;
 }
 
 export function createWebviewPanel(
-  context: vscode.ExtensionContext,
-  address: string
+  context: vscode.ExtensionContext
 ) {
   const panel = vscode.window.createWebviewPanel(
     "AirCodum",
@@ -283,12 +309,17 @@ export function createWebviewPanel(
   panel.webview.html = getWebviewContent();
 
 
-  // Send the IP address to the webview
-  panel.webview.postMessage({ type: "ipAddress", ipAddress: address });
+  const sendConnection = () => {
+    const server = store.getState().server;
+    const configured = vscode.workspace.getConfiguration("aircodum").get<string>("bindAddress", "127.0.0.1");
+    panel.webview.postMessage({ type: "connection", ...connectionDetails(server, configured) });
+  };
+  const unsubscribe = store.subscribe(sendConnection);
 
   // Add this event listener
   panel.onDidDispose(
     () => {
+      unsubscribe();
       setWebviewPanel(null);
     },
     null,
@@ -302,8 +333,20 @@ export function createWebviewPanel(
         case "addToCurrentFile":
           addToCurrentFile(message.text);
           break;
-        case "ipAddress":
-          panel?.webview.postMessage({ type: "ipAddress", ipAddress: address });
+        case "connection":
+          sendConnection();
+          break;
+        case "configureConnection":
+          await vscode.commands.executeCommand("extension.configureAirCodumConnection");
+          break;
+        case "copyPairingToken":
+          await vscode.commands.executeCommand("extension.copyAirCodumPairingToken");
+          break;
+        case "startServer":
+          await vscode.commands.executeCommand("extension.startAirCodumServer");
+          break;
+        case "stopServer":
+          await vscode.commands.executeCommand("extension.stopAirCodumServer");
           break;
         case "saveApiKey":
           await saveApiKey(message.key);

--- a/extension/tests/connection.test.cjs
+++ b/extension/tests/connection.test.cjs
@@ -1,0 +1,25 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { tailscaleAddresses, connectionDetails } = require('../src/connection.ts');
+
+test('connection choices contain detected Tailscale addresses, never public or LAN adapters', () => {
+  const address = (address, internal = false) => ({ address, internal });
+  assert.deepEqual(tailscaleAddresses({
+    lo: [address('127.0.0.1', true)],
+    en0: [address('192.168.1.2'), address('10.0.0.2'), address('8.8.8.8')],
+    utun: [address('100.89.59.102'), address('fd7a:115c:a1e0::1234')],
+    duplicate: [address('100.89.59.102')],
+  }), ['100.89.59.102']);
+  assert.deepEqual(tailscaleAddresses({}), []);
+});
+
+test('panel reports the actual listener until restarted, and explains local-only access', () => {
+  const server = { isRunning: true, address: '127.0.0.1', port: 11040 };
+  const active = connectionDetails(server, '100.89.59.102');
+  assert.equal(active.host, '127.0.0.1');
+  assert.match(active.hint, /only from this Mac/);
+  const stopped = connectionDetails({ ...server, isRunning: false }, '100.89.59.102');
+  assert.equal(stopped.host, '100.89.59.102');
+  assert.match(stopped.hint, /Server stopped/);
+  assert.equal(connectionDetails({ ...server, address: '100.89.59.102' }, '127.0.0.1').running, true);
+});

--- a/extension/tests/connection.test.cjs
+++ b/extension/tests/connection.test.cjs
@@ -23,3 +23,17 @@ test('panel reports the actual listener until restarted, and explains local-only
   assert.match(stopped.hint, /Server stopped/);
   assert.equal(connectionDetails({ ...server, address: '100.89.59.102' }, '127.0.0.1').running, true);
 });
+
+const { pairingCode } = require('../src/connection.ts');
+const QRCode = require('qrcode');
+const { PNG } = require('pngjs');
+const jsQR = require('jsqr');
+test('pairing image decodes to the complete versioned phone connection', async () => {
+ const token='a'.repeat(64);
+ const payload=pairingCode({isRunning:true,address:'100.89.59.102',port:11040},token);
+ const png=PNG.sync.read(await QRCode.toBuffer(payload,{width:640,margin:4,errorCorrectionLevel:'M'}));
+ const decoded=jsQR(new Uint8ClampedArray(png.data),png.width,png.height);
+ assert.equal(decoded.data,payload);
+ assert.deepEqual(JSON.parse(decoded.data),{type:'aircodum-pairing',version:1,host:'100.89.59.102',port:11040,tls:false,token});
+ for(const state of [{isRunning:false,address:'100.89.59.102',port:11040},{isRunning:true,address:'127.0.0.1',port:11040}]) assert.throws(()=>pairingCode(state,token));
+});

--- a/extension/tests/keep-awake.test.cjs
+++ b/extension/tests/keep-awake.test.cjs
@@ -1,0 +1,13 @@
+const {test}=require('node:test');const assert=require('node:assert/strict');const {EventEmitter}=require('node:events');const Module=require('node:module');
+const calls=[];const original=Module._load;let child;
+Module._load=function(name,...rest){if(name==='child_process')return {spawn:(file,args,options)=>{calls.push({file,args,options});child=new EventEmitter();child.pid=123;child.kill=()=>{child.killed=true};return child;}};return original.call(this,name,...rest);};
+const {KeepAwake}=require('../src/keep-awake.ts');Module._load=original;
+test('awake assertion is opted in, scoped to the extension PID and released when server stops',()=>{
+ let changes=0;const awake=new KeepAwake(()=>changes++,()=>{});
+ awake.update(false,true);awake.update(true,false);assert.equal(calls.length,0);
+ awake.update(true,true);
+ if(process.platform!=='darwin'){assert.equal(calls.length,0);return;}
+ assert.deepEqual(calls[0],{file:'/usr/bin/caffeinate',args:['-is','-w',String(process.pid)],options:{stdio:'ignore'}});
+ awake.update(true,true);assert.equal(calls.length,1);assert.equal(awake.active,true);
+ child.emit('spawn');assert.equal(changes,1);awake.update(true,false);assert.equal(child.killed,true);assert.equal(awake.active,false);
+});

--- a/extension/tests/server.test.cjs
+++ b/extension/tests/server.test.cjs
@@ -23,6 +23,11 @@ const message = socket => once(socket, 'message').then(([data]) => JSON.parse(da
 test('extension requires pairing, streams only on demand, rejects malformed text and releases listener', async () => {
   store.setState({ server: { port: 0, isRunning: false, address: null } });
   await assert.rejects(startServer('0.0.0.0', token));
+  const occupied = require('net').createServer(); occupied.listen(0, '127.0.0.1'); await once(occupied, 'listening');
+  store.setState({ server: { port: occupied.address().port, isRunning: false, address: null } });
+  await assert.rejects(startServer('127.0.0.1', token), /EADDRINUSE/);
+  await new Promise(resolve => occupied.close(resolve));
+  store.setState({ server: { port: 0, isRunning: false, address: null } });
   await startServer('127.0.0.1', token);
   const wss = store.getState().websocket.wss;
   const port = wss.address().port;
@@ -40,6 +45,9 @@ test('extension requires pairing, streams only on demand, rejects malformed text
     assert.equal(capabilities.features.pty, false);
     assert.deepEqual(capabilities.features.agents, []);
     assert.equal(captures, 0);
+    assert.equal(capabilities.features.heartbeat, true);
+    const pong = message(client); client.send(JSON.stringify({type: 'ping'}));
+    assert.equal((await pong).type, 'pong');
     const rejected = message(client); client.send('{broken');
     assert.equal((await rejected).type, 'error'); assert.equal(uploads, 0);
     const frame = message(client); client.send(JSON.stringify({ type: 'vnc_start' }));

--- a/extension/tests/server.test.cjs
+++ b/extension/tests/server.test.cjs
@@ -4,10 +4,11 @@ const { once } = require('node:events');
 const Module = require('node:module');
 const { WebSocket } = require('ws');
 let captures = 0, uploads = 0, taps = [], typed = [], modifiers = [];
+const connectionEvents = [];
 const native = { getScreenSize: () => ({ width: 1440, height: 900 }), keyTap: (key, held = []) => { taps.push(key); modifiers = held; }, keyToggle: key => { modifiers = modifiers.filter(m => m !== key); }, moveMouse() {}, mouseToggle() {}, typeString(text) { if (!modifiers.length) typed.push(text); } };
 const originalLoad = Module._load;
 Module._load = function(name, ...args) {
-  if (name === 'vscode') return { workspace: { isTrusted: true }, window: { showInformationMessage() {} } };
+  if (name === 'vscode') return { workspace: { isTrusted: true }, window: { showInformationMessage() {}, createOutputChannel() { return { appendLine: line => connectionEvents.push(line), dispose() {} }; } } };
   if (name === './commanding/robotjs-handlers') return { typedRobot: native };
   if (name === './native-capture') return { capturePrimaryScreen: async () => { captures++; return Buffer.alloc(4096); }, nativeResizeJpeg: async () => null };
   if (name === './jimp') return { createImage: async () => ({ width: 1440, height: 900, getBuffer: async () => Buffer.from('frame') }) };
@@ -17,6 +18,7 @@ Module._load = function(name, ...args) {
 };
 const { startServer, stopServer } = require('../src/server.ts');
 const { store } = require('../src/state/store.ts');
+require('../src/connection-log.ts').initializeConnectionLog({ subscriptions: [] });
 Module._load = originalLoad;
 const token = 'c'.repeat(64);
 const message = socket => once(socket, 'message').then(([data]) => JSON.parse(data.toString()));
@@ -35,6 +37,16 @@ test('extension requires pairing, streams only on demand, rejects malformed text
   try {
     const bad = new WebSocket(`ws://127.0.0.1:${port}`);
     await new Promise(resolve => bad.on('error', resolve));
+    const wrong = new WebSocket(`ws://127.0.0.1:${port}`, { headers: { Authorization: 'Bearer sensitive-invalid-key' } });
+    await new Promise(resolve => wrong.on('error', resolve));
+    const tls = require('net').connect(port, '127.0.0.1');
+    await once(tls, 'connect');
+    tls.write(Buffer.from([0x16, 0x03, 0x01, 0, 0]));
+    await once(tls, 'close');
+    assert.ok(connectionEvents.some(line => line.includes('missing pairing key')));
+    assert.ok(connectionEvents.some(line => line.includes('incorrect pairing key')));
+    assert.ok(connectionEvents.some(line => line.includes('TLS requested on plain WebSocket port')));
+    assert.ok(connectionEvents.every(line => !line.includes(token) && !line.includes('sensitive-invalid-key')));
     assert.equal(captures, 0);
     client = new WebSocket(`ws://127.0.0.1:${port}`, { headers: { Authorization: 'Bearer ' + token } });
     const hello = message(client);


### PR DESCRIPTION
The extension previously mixed pairing, server controls, power settings, API-key setup and chat into one panel with equally prominent buttons. This redesign gives connection setup one main action, keeps QR and manual pairing in visible tabs, and groups server controls and troubleshooting in a collapsible section. Files and optional AI tools have a separate tab with a new-content indicator.

The panel now shows active connection status, follows VS Code theme colors, fits narrow editor panes and supports keyboard tab navigation. Keep Mac awake is an explicit checkbox with enabled/active states. Manual key copy, QR clearing, received content, AI setup and editor insertion remain supported.

Validation: TypeScript and 10 existing regression tests pass. Chromium checks cover the UI actions, keyboard tabs, late QR results after stopping, credential-image clearing, file text escaping, optional AI setup, and widths from 320 to 1100 px in dark/light themes. The packaged 0.2.5 VSIX passed real VS Code checks for an authenticated connection, key copy, start/stop, keep-awake, address selection, log opening and a decodable pairing QR.

This follows #29 and includes its diagnostics. Version 0.2.5 is installed and running in the normal VS Code window. The active native-module path, new UI controls and authenticated listener/capabilities response were verified after reload. Marketplace 0.2.5 is publicly available. The downloaded public VSIX exactly matches the tested package (SHA-256 22f0820e1f90a9b9150aebea946eabb94e0052e3e8003afb2cf5afacbec914a8).
